### PR TITLE
feat: improve type safety of Entity constructor inputs

### DIFF
--- a/packages/sdk/src/store/tests/database.test.ts
+++ b/packages/sdk/src/store/tests/database.test.ts
@@ -111,7 +111,9 @@ describe('Test Database', () => {
       gas: 100n,
       count: 0,
       gasPrice: new BigDecimal('100.0'),
-      raw: new Uint8Array([1, 2, 3])
+      raw: new Uint8Array([1, 2, 3]),
+      arrayValue: [],
+      arrayOfArrayValue: []
     })
     await store.upsert(tx)
 

--- a/packages/sdk/src/store/tests/generated/schema.ts
+++ b/packages/sdk/src/store/tests/generated/schema.ts
@@ -16,6 +16,21 @@ export interface Owner {
   name: String
 }
 
+interface TransactionConstructorInput {
+  id: ID
+  senderID?: ID
+  gas: BigInt
+  gasPrice: BigDecimal
+  isSuccess?: Boolean
+  raw?: Bytes
+  count?: Int
+  value?: Float
+  arrayValue: Array<String>
+  arrayValue2?: Array<String>
+  arrayOfArrayValue: Array<Array<String>>
+  dateValue?: Timestamp
+  receiptsIDs?: Array<ID>
+}
 @Entity('Transaction')
 export class Transaction extends AbstractEntity {
   @Required
@@ -68,11 +83,16 @@ export class Transaction extends AbstractEntity {
   receipts: Promise<Array<TransactionReceipt>>
 
   receiptsIDs: Array<ID | undefined>
-  constructor(data: Partial<Transaction>) {
+  constructor(data: TransactionConstructorInput) {
     super()
   }
 }
 
+interface TransactionReceiptConstructorInput {
+  id: ID
+  status?: TransactionStatus
+  transactionID?: ID
+}
 @Entity('TransactionReceipt')
 export class TransactionReceipt extends AbstractEntity {
   @Required
@@ -86,11 +106,17 @@ export class TransactionReceipt extends AbstractEntity {
   transaction: Promise<Transaction | undefined>
 
   transactionID: ID
-  constructor(data: Partial<TransactionReceipt>) {
+  constructor(data: TransactionReceiptConstructorInput) {
     super()
   }
 }
 
+interface UserConstructorInput {
+  id: ID
+  name: String
+  transactionsIDs?: Array<ID>
+  organizationsIDs?: Array<ID>
+}
 @Entity('User')
 export class User extends AbstractEntity implements Owner {
   @Required
@@ -112,11 +138,16 @@ export class User extends AbstractEntity implements Owner {
   organizations: Promise<Array<Organization>>
 
   organizationsIDs: Array<ID | undefined>
-  constructor(data: Partial<User>) {
+  constructor(data: UserConstructorInput) {
     super()
   }
 }
 
+interface OrganizationConstructorInput {
+  id: ID
+  name: String
+  membersIDs?: Array<ID>
+}
 @Entity('Organization')
 export class Organization extends AbstractEntity implements Owner {
   @Required
@@ -132,7 +163,7 @@ export class Organization extends AbstractEntity implements Owner {
   members: Promise<Array<User>>
 
   membersIDs: Array<ID | undefined>
-  constructor(data: Partial<Organization>) {
+  constructor(data: OrganizationConstructorInput) {
     super()
   }
 }
@@ -163,7 +194,7 @@ type TransactionReceipt @entity {
   transaction: Transaction
 }
 
-interface Owner  {
+interface Owner {
   id: ID!
   name: String!
 }
@@ -188,7 +219,8 @@ type NonEntity {
 enum TransactionStatus {
   SUCCESS
   FAILURE
-}`
+}
+`
 DatabaseSchema.register({
   source,
   entities: {

--- a/packages/sdk/src/store/tests/schema.graphql
+++ b/packages/sdk/src/store/tests/schema.graphql
@@ -20,7 +20,7 @@ type TransactionReceipt @entity {
   transaction: Transaction
 }
 
-interface Owner  {
+interface Owner {
   id: ID!
   name: String!
 }


### PR DESCRIPTION
#### Description

Enhances type safety in Entity constructors by generating strict TypeScript interfaces for constructor inputs. Required fields (marked with `@Required`) must be provided in the constructor, while optional fields remain optional. This prevents runtime errors by catching missing required fields at compile time.

Key changes:
- Generates specific `ConstructorInput` interfaces for each Entity
- Makes `@Required` fields mandatory in constructor types
- Excludes Promise-wrapped relationship fields from constructor inputs
- Properly handles array fields and relationships via ID fields

Fixes runtime errors that could occur when required fields are omitted during Entity instantiation.

Fixes #1088