### PR TITLE
feat: expose memory database for testing

### DIFF
--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -2,3 +2,5 @@ export { TestProcessorServer } from './test-processor-server.js'
 export { MetricValueToNumber, firstCounterValue, firstGaugeValue } from './metric-utils.js'
 
 export { loadTestProvidersFromEnv } from './test-provider.js' // TODO make the interface more standard and then export
+
+export { MemoryDatabase, withStoreContext } from './memory-database.js'


### PR DESCRIPTION
#### Description

Export `MemoryDatabase` and `withStoreContext` so that developers can use them in their processors by importing from `@sentio/sdk/testing`
