### PR TITLE
fix(eth): Rename ERC721 to ERC20 in account processor

### DIFF
--- a/packages/sdk/src/eth/account-processor.ts
+++ b/packages/sdk/src/eth/account-processor.ts
@@ -61,7 +61,7 @@ export class AccountProcessor {
     return this.onERC20(
       handler,
       tokensAddresses,
-      (address: string) => ERC721Processor.filters.Transfer(null, this.config.address),
+      (address: string) => ERC20Processor.filters.Transfer(null, this.config.address),
       fetchConfig,
       preprocessHandler
     )


### PR DESCRIPTION
This commit tries to fix a typo. While the typo didn't cause functional issues, hope this change improve code readability and consistency.