### PR TITLE
Add endpoint commands to CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "@aptos-labs/ts-sdk": "~6.0.0",
     "@iota/iota-sdk": "~1.10.0",
     "@mysten/sui": "~2.4.0",
+    "@sentio/api": "1.0.4",
     "@sentio/chain": "~3.4.22",
     "@sentio/graph-cli": "^0.97.0",
     "@types/node": "^24.0.0",

--- a/packages/cli/src/api.test.ts
+++ b/packages/cli/src/api.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { resolveProjectRef } from './api.js'
+
+describe('api project resolution', () => {
+  const originalCwd = process.cwd()
+  const originalFetch = globalThis.fetch
+  let tempDir = ''
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sentio-cli-project-'))
+    process.chdir(tempDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    globalThis.fetch = originalFetch
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test('resolveProjectRef infers owner from current auth when sentio.yaml only contains slug', async () => {
+    fs.writeFileSync(path.join(tempDir, 'sentio.yaml'), 'project: coinbase\n')
+
+    globalThis.fetch = (async (input: string | URL) => {
+      const url = String(input)
+      if (url === 'https://api.sentio.xyz/v1/users') {
+        return new Response(JSON.stringify({ username: 'sentio' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      if (url === 'https://api.sentio.xyz/v1/project/sentio/coinbase') {
+        return new Response(JSON.stringify({ project: { id: 'R2QKMeul' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    }) as typeof globalThis.fetch
+
+    const project = await resolveProjectRef(
+      {},
+      {
+        host: 'https://app.sentio.xyz',
+        headers: {}
+      },
+      { ownerSlug: true, projectId: true }
+    )
+
+    expect(project).deep.equal({
+      owner: 'sentio',
+      slug: 'coinbase',
+      projectId: 'R2QKMeul'
+    })
+  })
+})

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,0 +1,501 @@
+import { client } from '@sentio/api'
+import chalk from 'chalk'
+import fs from 'fs'
+import path from 'path'
+import process from 'process'
+import yaml from 'yaml'
+import { getFinalizedHost } from './config.js'
+import { ReadKey } from './key.js'
+import { getApiUrl, getCliVersion } from './utils.js'
+
+export class CliError extends Error {}
+
+let apiDebugEnabled = false
+let originalFetch: typeof globalThis.fetch | undefined
+
+export interface ApiAuthOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+}
+
+export interface ProjectLookupOptions {
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+}
+
+export interface JsonInputOptions {
+  file?: string
+  stdin?: boolean
+}
+
+export interface ApiContext {
+  host: string
+  headers: Record<string, string>
+}
+
+export interface ApiResult<T> {
+  data?: T
+  error?: unknown
+  response?: {
+    status?: number
+    statusText?: string
+  }
+}
+
+export interface ProjectRef {
+  owner: string
+  slug: string
+  projectId?: string
+}
+
+interface ProjectInputRef {
+  owner?: string
+  slug: string
+}
+
+interface ProjectBySlugResponse {
+  project?: {
+    id?: string
+    ownerName?: string
+    slug?: string
+  }
+}
+
+interface ProjectByIdResponse {
+  id?: string
+  owner?: string
+  slug?: string
+}
+
+export function getApiBaseUrl(host: string) {
+  let apiHost = host
+  if (host.includes('sentio.xyz')) {
+    apiHost = host.replace('test', 'api-test').replace('staging', 'api-staging').replace('app', 'api')
+  }
+  return apiHost.endsWith('/') ? apiHost.slice(0, -1) : apiHost
+}
+
+export function enableApiDebug() {
+  if (apiDebugEnabled) {
+    return
+  }
+  apiDebugEnabled = true
+
+  if (!globalThis.fetch) {
+    return
+  }
+
+  originalFetch = globalThis.fetch.bind(globalThis)
+  globalThis.fetch = async (input: any, init?: RequestInit) => {
+    const method = init?.method ?? (typeof Request !== 'undefined' && input instanceof Request ? input.method : 'GET')
+    const url =
+      typeof input === 'string' || input instanceof URL
+        ? String(input)
+        : typeof input?.url === 'string'
+          ? input.url
+          : String(input)
+    const body = formatDebugBody(init?.body)
+
+    console.error(`[sentio debug] ${method.toUpperCase()} ${url}`)
+    if (body) {
+      console.error(`[sentio debug] body: ${body}`)
+    }
+
+    try {
+      const response = await originalFetch!(input, init)
+      console.error(`[sentio debug] response: ${response.status} ${response.statusText}`)
+      return response
+    } catch (error) {
+      console.error(`[sentio debug] request failed: ${String(error)}`)
+      throw error
+    }
+  }
+}
+
+export function createApiContext(options: ApiAuthOptions): ApiContext {
+  const host = getFinalizedHost(options.host)
+  client.setConfig({
+    baseUrl: getApiBaseUrl(host)
+  } as never)
+
+  let apiKey = ReadKey(host)
+  if (options.apiKey) {
+    apiKey = options.apiKey
+  }
+
+  if (apiKey) {
+    return {
+      host,
+      headers: {
+        'api-key': apiKey,
+        version: getCliVersion()
+      }
+    }
+  }
+
+  if (options.token) {
+    return {
+      host,
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+        version: getCliVersion()
+      }
+    }
+  }
+
+  const loginCommand = host === 'https://app.sentio.xyz' ? 'sentio login' : `sentio login --host=${host}`
+  throw new CliError(`No credential found for ${host}. Please run \`${loginCommand}\`.`)
+}
+
+export function loadJsonInput(options: JsonInputOptions): unknown | undefined {
+  if (options.file && options.stdin) {
+    throw new CliError('Use either --file or --stdin, not both.')
+  }
+
+  if (options.file) {
+    return parseStructuredInput(fs.readFileSync(options.file, 'utf8'), `file ${options.file}`, options.file)
+  }
+
+  if (options.stdin) {
+    if (process.stdin.isTTY) {
+      throw new CliError('Expected JSON or YAML from stdin, but stdin is empty.')
+    }
+    return parseStructuredInput(fs.readFileSync(0, 'utf8'), 'stdin')
+  }
+
+  return undefined
+}
+
+export function parseProjectSlug(project: string): Pick<ProjectRef, 'owner' | 'slug'> {
+  const [owner, slug, ...rest] = project.split('/')
+  if (!owner || !slug || rest.length > 0) {
+    throw new CliError(`Invalid project "${project}". Expected <owner>/<slug>.`)
+  }
+  return { owner, slug }
+}
+
+export function loadProjectFromConfig(cwd = process.cwd()): string | undefined {
+  const yamlPath = path.join(cwd, 'sentio.yaml')
+  if (!fs.existsSync(yamlPath)) {
+    return undefined
+  }
+
+  try {
+    const config = yaml.parse(fs.readFileSync(yamlPath, 'utf8')) as { project?: string } | null
+    return config?.project
+  } catch (error) {
+    throw new CliError(`Failed to read ${yamlPath}: ${String(error)}`)
+  }
+}
+
+export function resolveProjectSlugInput(
+  options: ProjectLookupOptions,
+  cwd = process.cwd()
+): Pick<ProjectRef, 'owner' | 'slug'> {
+  if (options.project) {
+    return parseProjectSlug(options.project)
+  }
+
+  if (options.owner && options.name) {
+    return { owner: options.owner, slug: options.name }
+  }
+
+  if (!options.owner && options.name?.includes('/')) {
+    return parseProjectSlug(options.name)
+  }
+
+  const configProject = loadProjectFromConfig(cwd)
+  if (configProject) {
+    return parseProjectSlug(configProject)
+  }
+
+  throw new CliError(
+    'Project is required. Use --project <owner/slug>, --owner with --name, or run inside a Sentio project.'
+  )
+}
+
+function parseProjectInput(project: string): ProjectInputRef {
+  const parts = project.split('/')
+  if (parts.length === 1 && parts[0]) {
+    return { slug: parts[0] }
+  }
+  if (parts.length === 2 && parts[0] && parts[1]) {
+    return { owner: parts[0], slug: parts[1] }
+  }
+  throw new CliError(`Invalid project "${project}". Expected <owner>/<slug> or <slug>.`)
+}
+
+function resolveProjectInput(options: ProjectLookupOptions, cwd = process.cwd()): ProjectInputRef {
+  if (options.project) {
+    return parseProjectInput(options.project)
+  }
+
+  if (options.owner && options.name) {
+    return { owner: options.owner, slug: options.name }
+  }
+
+  if (!options.owner && options.name?.includes('/')) {
+    return parseProjectInput(options.name)
+  }
+
+  if (!options.owner && options.name) {
+    return { slug: options.name }
+  }
+
+  const configProject = loadProjectFromConfig(cwd)
+  if (configProject) {
+    return parseProjectInput(configProject)
+  }
+
+  throw new CliError(
+    'Project is required. Use --project <owner/slug>, --owner with --name, --project-id, or run inside a Sentio project.'
+  )
+}
+
+export async function resolveProjectRef(
+  options: ProjectLookupOptions,
+  context: ApiContext,
+  requirements: { ownerSlug?: boolean; projectId?: boolean } = { ownerSlug: true }
+): Promise<ProjectRef> {
+  let owner: string | undefined
+  let slug: string | undefined
+  let projectId = options.projectId
+
+  try {
+    const parsed = resolveProjectInput(options)
+    owner = parsed.owner
+    slug = parsed.slug
+  } catch (error) {
+    if (!(error instanceof CliError) || !projectId) {
+      throw error
+    }
+  }
+
+  if ((!owner || !slug) && projectId) {
+    const data = await getProjectById(projectId, context)
+    owner = data?.owner
+    slug = data?.slug
+    if (!owner || !slug) {
+      throw new CliError(`Unable to resolve project ${projectId}.`)
+    }
+  }
+
+  if ((!owner || !slug) && requirements.ownerSlug) {
+    if (!owner && slug) {
+      owner = await getCurrentOwnerName(context)
+    }
+  }
+
+  if ((!owner || !slug) && requirements.ownerSlug) {
+    throw new CliError(
+      'Project is required. Use --project <owner/slug>, --owner with --name, --project-id, or run inside a Sentio project.'
+    )
+  }
+
+  if (!projectId && requirements.projectId) {
+    if (!owner || !slug) {
+      throw new CliError('Project id resolution requires a project slug.')
+    }
+    const data = await getProjectBySlug(owner, slug, context)
+    projectId = data?.project?.id
+    if (!projectId) {
+      throw new CliError(`Unable to resolve project id for ${owner}/${slug}.`)
+    }
+  }
+
+  return {
+    owner: owner!,
+    slug: slug!,
+    projectId
+  }
+}
+
+async function getCurrentOwnerName(context: ApiContext): Promise<string> {
+  const user = await fetchApiJson<{ username?: string }>('/api/v1/users', context)
+  if (!user.username) {
+    throw new CliError('Unable to resolve project owner from current auth. Use --project <owner/slug> explicitly.')
+  }
+  return user.username
+}
+
+export function handleCommandError(error: unknown): never {
+  if (error instanceof CliError) {
+    console.error(chalk.red(error.message))
+    process.exit(1)
+  }
+
+  const response = (error as { response?: { status?: number; statusText?: string } })?.response
+  if (response) {
+    const status = response.status ?? 'unknown'
+    const statusText = response.statusText ?? ''
+    console.error(chalk.red(`Sentio API request failed: ${status} ${statusText}`.trim()))
+    process.exit(1)
+  }
+
+  const cause = (error as { cause?: { code?: string; hostname?: string } })?.cause
+  if (error instanceof TypeError && String(error.message).includes('fetch failed')) {
+    const detail =
+      cause?.code && cause?.hostname ? `${cause.code} (${cause.hostname})` : cause?.code ? cause.code : error.message
+    console.error(chalk.red(`Sentio API request failed: ${detail}`))
+    process.exit(1)
+  }
+
+  console.error(error)
+  process.exit(1)
+}
+
+export function unwrapApiResult<T>(result: ApiResult<T>): T {
+  if (result.error) {
+    const errorDetail = formatApiError(result.error)
+    const statusDetail = result.response?.status
+      ? `${result.response.status} ${result.response.statusText ?? ''}`.trim()
+      : undefined
+    throw new CliError(
+      `Sentio API returned an error${statusDetail ? ` (${statusDetail})` : ''}: ${errorDetail || 'unknown error'}`
+    )
+  }
+  if (result.data === undefined) {
+    throw new CliError('Sentio API returned no data.')
+  }
+  return result.data
+}
+
+export async function fetchApiJson<T>(
+  apiPath: string,
+  context: ApiContext,
+  query?: Record<string, string | number | boolean | undefined>
+): Promise<T> {
+  const url = getApiUrl(apiPath, context.host)
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value))
+      }
+    }
+  }
+  const response = await fetch(url.href, {
+    method: 'GET',
+    headers: context.headers
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new CliError(
+      `Sentio API request failed: ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}`
+    )
+  }
+  return (await response.json()) as T
+}
+
+export async function postApiJson<T>(
+  apiPath: string,
+  context: ApiContext,
+  body: unknown,
+  query?: Record<string, string | number | boolean | undefined>
+): Promise<T> {
+  const url = getApiUrl(apiPath, context.host)
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value))
+      }
+    }
+  }
+  const response = await fetch(url.href, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...context.headers
+    },
+    body: JSON.stringify(body)
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new CliError(
+      `Sentio API request failed: ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}`
+    )
+  }
+  return (await response.json()) as T
+}
+
+function parseStructuredInput(content: string, source: string, filename?: string) {
+  if (!content.trim()) {
+    throw new CliError(`Expected JSON or YAML in ${source}, but it was empty.`)
+  }
+
+  const isYamlFile = filename ? /\.ya?ml$/i.test(filename) : false
+
+  try {
+    return isYamlFile ? yaml.parse(content) : JSON.parse(content)
+  } catch (jsonError) {
+    if (!isYamlFile) {
+      try {
+        return yaml.parse(content)
+      } catch (yamlError) {
+        throw new CliError(`Invalid JSON or YAML from ${source}: ${String(yamlError)}`)
+      }
+    }
+    throw new CliError(`Invalid JSON or YAML from ${source}: ${String(jsonError)}`)
+  }
+}
+
+export async function getProjectBySlug(
+  owner: string,
+  slug: string,
+  context: ApiContext
+): Promise<ProjectBySlugResponse> {
+  const response = await fetch(getApiUrl(`/api/v1/project/${owner}/${slug}`, context.host).href, {
+    method: 'GET',
+    headers: context.headers
+  })
+  if (!response.ok) {
+    throw new CliError(`Failed to resolve project ${owner}/${slug}: ${response.status} ${response.statusText}`)
+  }
+  return (await response.json()) as ProjectBySlugResponse
+}
+
+export async function getProjectById(projectId: string, context: ApiContext): Promise<ProjectByIdResponse> {
+  const response = await fetch(getApiUrl(`/api/v1/project/${projectId}`, context.host).href, {
+    method: 'GET',
+    headers: context.headers
+  })
+  if (!response.ok) {
+    throw new CliError(`Failed to resolve project ${projectId}: ${response.status} ${response.statusText}`)
+  }
+  return (await response.json()) as ProjectByIdResponse
+}
+
+function formatApiError(error: unknown) {
+  if (typeof error === 'string') {
+    return error
+  }
+  if (error && typeof error === 'object') {
+    const maybeMessage = (error as { message?: string }).message
+    if (maybeMessage) {
+      return maybeMessage
+    }
+    try {
+      const serialized = JSON.stringify(error)
+      return serialized === '{}' ? '' : serialized
+    } catch {}
+  }
+  return String(error)
+}
+
+function formatDebugBody(body: any) {
+  if (!body) {
+    return ''
+  }
+  if (typeof body === 'string') {
+    return body
+  }
+  if (body instanceof URLSearchParams) {
+    return body.toString()
+  }
+  if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
+    return '<binary>'
+  }
+  return `<${body.constructor?.name ?? 'body'}>`
+}

--- a/packages/cli/src/commands/alert.test.ts
+++ b/packages/cli/src/commands/alert.test.ts
@@ -1,0 +1,128 @@
+import { describe, test } from 'node:test'
+import { expect } from 'chai'
+import { buildAlertRuleBodyFromSpec } from './alert.js'
+
+describe('alert command helpers', () => {
+  test('buildAlertRuleBodyFromSpec creates log alert payload', async () => {
+    const body = await buildAlertRuleBodyFromSpec({
+      projectId: 'project-1',
+      type: 'LOG',
+      subject: 'Large transfer logs',
+      query: 'amount > 1000',
+      op: '>',
+      threshold: 0,
+      for: '5m'
+    })
+
+    expect(body.rule).deep.include({
+      projectId: 'project-1',
+      alertType: 'LOG',
+      subject: 'Large transfer logs'
+    })
+    expect(body.rule?.logCondition).deep.equal({
+      query: 'amount > 1000',
+      comparisonOp: '>',
+      threshold: 0,
+      threshold2: undefined
+    })
+    expect(body.rule?.for).deep.equal({
+      value: 5,
+      unit: 'm'
+    })
+  })
+
+  test('buildAlertRuleBodyFromSpec creates inline metric alert payload', async () => {
+    const body = await buildAlertRuleBodyFromSpec({
+      projectId: 'project-1',
+      type: 'METRIC',
+      subject: 'Burn spike',
+      metric: 'burn',
+      filter: ['meta.chain=1'],
+      groupBy: ['meta.address'],
+      aggr: 'avg',
+      op: '>',
+      threshold: 100
+    })
+
+    expect(body.rule).deep.include({
+      projectId: 'project-1',
+      alertType: 'METRIC',
+      subject: 'Burn spike'
+    })
+    const condition = body.rule?.condition as any
+    expect(condition.comparisonOp).eq('>')
+    expect(condition.threshold).eq(100)
+    expect(condition.insightQueries).length(1)
+    expect(condition.insightQueries[0].metricsQuery).deep.include({
+      id: 'a',
+      query: 'burn'
+    })
+    expect(condition.insightQueries[0].metricsQuery.labelSelector).deep.equal({
+      'meta.chain': '1'
+    })
+  })
+
+  test('buildAlertRuleBodyFromSpec creates metric alert payload from yaml-style multi-query spec', async () => {
+    const body = await buildAlertRuleBodyFromSpec({
+      projectId: 'project-1',
+      type: 'METRIC',
+      subject: 'Net flow anomaly',
+      queries: [
+        {
+          id: 'a',
+          metric: 'inflow',
+          filter: ['meta.chain=1'],
+          aggr: 'sum'
+        },
+        {
+          id: 'b',
+          metric: 'outflow',
+          filter: ['meta.chain=1'],
+          aggr: 'sum'
+        }
+      ],
+      formula: 'a - b',
+      op: '>',
+      threshold: 100000,
+      interval: '1m'
+    })
+
+    const condition = body.rule?.condition as any
+    expect(condition.insightQueries).length(2)
+    expect(condition.formula).deep.equal({
+      expression: 'a - b',
+      disabled: false
+    })
+    expect(body.rule?.interval).deep.equal({
+      value: 1,
+      unit: 'm'
+    })
+  })
+
+  test('buildAlertRuleBodyFromSpec creates sql alert payload', async () => {
+    const body = await buildAlertRuleBodyFromSpec({
+      projectId: 'project-1',
+      type: 'SQL',
+      subject: 'Large transfer(SQL demo)',
+      query: 'select timestamp, amount from transfer',
+      timeColumn: 'timestamp',
+      valueColumn: 'amount',
+      sqlAggr: 'MAX',
+      op: '>',
+      threshold: 1000
+    })
+
+    expect(body.rule?.query).eq('select timestamp, amount from transfer')
+    expect(body.rule?.sqlCondition).deep.equal({
+      sqlQuery: 'select timestamp, amount from transfer',
+      columnCondition: {
+        valueColumn: 'amount',
+        timeColumn: 'timestamp',
+        comparisonOp: '>',
+        threshold: 1000,
+        threshold2: undefined,
+        aggregation: 'MAX'
+      }
+    })
+  })
+})

--- a/packages/cli/src/commands/alert.ts
+++ b/packages/cli/src/commands/alert.ts
@@ -1,0 +1,940 @@
+import { AlertsService } from '@sentio/api'
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings'
+import process from 'process'
+import yaml from 'yaml'
+import {
+  CliError,
+  createApiContext,
+  handleCommandError,
+  loadJsonInput,
+  resolveProjectRef,
+  unwrapApiResult
+} from '../api.js'
+import { buildEventsInsightQueryBody, buildMetricsInsightQueryBody } from './data.js'
+
+interface AlertOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+  file?: string
+  stdin?: boolean
+  json?: boolean
+  yaml?: boolean
+}
+
+interface AlertCreateOptions extends AlertOptions {
+  doc?: boolean
+  type?: string
+  subject?: string
+  message?: string
+  query?: string
+  event?: string
+  metric?: string
+  alias?: string
+  sourceName?: string
+  filter?: string[]
+  groupBy?: string[]
+  aggr?: string
+  func?: string[]
+  op?: string
+  threshold?: number
+  threshold2?: number
+  for?: string
+  interval?: string
+  valueColumn?: string
+  timeColumn?: string
+  sqlAggr?: string
+}
+
+interface AlertGetOptions extends AlertOptions {
+  page?: number
+  pageSize?: number
+}
+
+interface AlertListOptions extends AlertOptions {
+  recent?: number
+}
+
+interface AlertRuleBody {
+  rule?: {
+    id?: string
+    projectId?: string
+    state?: string
+    subject?: string
+    message?: string
+    group?: string
+    query?: string
+    alertType?: string
+    mute?: boolean
+    channels?: Array<{ type?: string; name?: string }>
+    [key: string]: unknown
+  }
+}
+interface AlertQuerySpec {
+  id?: string
+  event?: string
+  metric?: string
+  alias?: string
+  sourceName?: string
+  filter?: string[] | string
+  groupBy?: string[] | string
+  aggr?: string
+  func?: string[] | string
+}
+
+export function createAlertCommand() {
+  const alertCommand = new Command('alert').description('Manage Sentio alerts')
+  alertCommand.addCommand(createAlertListCommand())
+  alertCommand.addCommand(createAlertGetCommand())
+  alertCommand.addCommand(createAlertCreateCommand())
+  alertCommand.addCommand(createAlertUpdateCommand())
+  alertCommand.addCommand(createAlertDeleteCommand())
+  return alertCommand
+}
+
+function createAlertListCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('list').description('List alert rules for a project')))
+  )
+    .showHelpAfterError()
+    .option('--recent <count>', 'Show the most recent N alert instances under each rule', parseInteger, 3)
+    .action(async (options, command) => {
+      try {
+        await runAlertList(options)
+      } catch (error) {
+        handleAlertCommandError(error, command)
+      }
+    })
+}
+
+function createAlertGetCommand() {
+  return withOutputOptions(withAuthOptions(new Command('get').description('Get an alert rule').argument('<rule-id>')))
+    .showHelpAfterError()
+    .option('--page <page>', 'Page number', parseInteger)
+    .option('--page-size <count>', 'Page size', parseInteger)
+    .action(async (ruleId, options, command) => {
+      try {
+        await runAlertGet(ruleId, options)
+      } catch (error) {
+        handleAlertCommandError(error, command)
+      }
+    })
+}
+
+function createAlertCreateCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('create').description('Create an alert rule')))
+  )
+    .showHelpAfterError()
+    .option('--file <path>', 'Read request JSON or YAML from file. Use --doc to show the full alert request format')
+    .option('--stdin', 'Read request JSON or YAML from stdin. Use --doc to show the full alert request format')
+    .option('--doc', 'Print the full alert request file format and exit')
+    .option('--type <type>', 'Alert type: METRIC, LOG, or SQL')
+    .option('--subject <text>', 'Alert subject/title')
+    .option('--message <text>', 'Optional alert message template')
+    .option('--query <text>', 'Inline log query or SQL when not using --file/--stdin')
+    .option('--event <name>', 'Inline event query for METRIC alerts')
+    .option('--metric <name>', 'Inline metric query for METRIC alerts')
+    .option('--alias <alias>', 'Alias for the inline METRIC query')
+    .option('--source-name <name>', 'Optional source name for the inline METRIC query')
+    .option('--filter <selector>', 'Inline METRIC query filter like amount>0 or meta.chain=1', collectOption, [])
+    .option('--group-by <field>', 'Inline METRIC query group-by field', collectOption, [])
+    .option(
+      '--aggr <aggregation>',
+      'Inline aggregation. METRIC: avg|sum|min|max|count. EVENTS: total|unique|AAU|DAU|WAU|MAU'
+    )
+    .option('--func <function>', 'Inline function like topk(1), bottomk(1), delta(1m)', collectOption, [])
+    .option('--op <operator>', 'Condition operator like >, >=, ==, !=, <, <=, between')
+    .option('--threshold <value>', 'Condition threshold', parseNumber)
+    .option('--threshold2 <value>', 'Second threshold for between', parseNumber)
+    .option('--for <duration>', 'Evaluate over the last duration, for example 5m or 1h')
+    .option('--interval <duration>', 'Alert evaluation interval, for example 1m or 5m')
+    .option('--time-column <column>', 'SQL alert time column for column-based conditions')
+    .option('--value-column <column>', 'SQL alert value column for column-based conditions')
+    .option('--sql-aggr <aggregation>', 'SQL aggregation: COUNT, SUM, AVG, MAX, MIN, LAST')
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio alert create --project sentio/coinbase --type LOG --subject "Large transfer logs" --query 'amount > 1000' --op '>' --threshold 0
+  $ sentio alert create --project sentio/coinbase --type SQL --subject "Large transfer(SQL demo)" --query 'select timestamp, amount from transfer where amount > 1000' --time-column timestamp --value-column amount --sql-aggr MAX --op '>' --threshold 1000
+  $ sentio alert create --project sentio/coinbase --type METRIC --subject "Burn spike" --metric burn --filter meta.chain=1 --aggr avg --group-by meta.address --op '>' --threshold 100
+  $ sentio alert create --project sentio/coinbase --type METRIC --subject "Transfer anomaly" --event Transfer --filter amount>0 --aggr total --func 'delta(1m)' --op '>' --threshold 100
+  $ sentio alert create --project sentio/coinbase --file alert.metric.yaml   # use --doc to show file format
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runAlertCreate(options)
+      } catch (error) {
+        handleAlertCommandError(error, command)
+      }
+    })
+}
+
+function createAlertUpdateCommand() {
+  return withOutputOptions(
+    withJsonInputOptions(
+      withAuthOptions(new Command('update').description('Update an alert rule').argument('<rule-id>'))
+    )
+  )
+    .showHelpAfterError()
+    .action(async (ruleId, options, command) => {
+      try {
+        await runAlertUpdate(ruleId, options)
+      } catch (error) {
+        handleAlertCommandError(error, command)
+      }
+    })
+}
+
+function createAlertDeleteCommand() {
+  return withOutputOptions(
+    withAuthOptions(new Command('delete').description('Delete an alert rule').argument('<rule-id>'))
+  )
+    .showHelpAfterError()
+    .action(async (ruleId, options, command) => {
+      try {
+        await runAlertDelete(ruleId, options)
+      } catch (error) {
+        handleAlertCommandError(error, command)
+      }
+    })
+}
+
+async function runAlertList(options: AlertListOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { projectId: true })
+  const response = await AlertsService.getAlertRules({
+    path: {
+      projectId: project.projectId!
+    },
+    headers: context.headers
+  })
+  const data = unwrapApiResult(response)
+  const rules = Array.isArray(data.rules) ? data.rules : []
+  const recentCount = options.recent ?? 3
+  const alertsByRule = Object.fromEntries(
+    await Promise.all(
+      rules.map(async (rule) => {
+        const ruleId = asString(rule.id)
+        if (!ruleId || recentCount <= 0) {
+          return [ruleId ?? '', []]
+        }
+        const detail = unwrapApiResult(
+          await AlertsService.getAlert({
+            path: {
+              ruleId
+            },
+            query: {
+              page: 1,
+              pageSize: recentCount
+            },
+            headers: context.headers
+          })
+        )
+        return [ruleId, Array.isArray(detail.alerts) ? detail.alerts : []]
+      })
+    )
+  )
+  printOutput(options, {
+    ...data,
+    alertsByRule,
+    recentCount
+  })
+}
+
+async function runAlertGet(ruleId: string, options: AlertGetOptions) {
+  const context = createApiContext(options)
+  const response = await AlertsService.getAlert({
+    path: {
+      ruleId
+    },
+    query: {
+      page: options.page,
+      pageSize: options.pageSize
+    },
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runAlertCreate(options: AlertCreateOptions) {
+  if (options.doc) {
+    console.log(ALERT_CREATE_DOC.trimEnd())
+    return
+  }
+
+  const context = createApiContext(options)
+  const body =
+    (await normalizeAlertRuleBody(loadJsonInput(options), options, context)) ??
+    (await buildAlertCreateBodyFromOptions(options, context))
+  if (!body) {
+    throw new CliError(
+      'Provide --file, --stdin, or inline alert flags like --type, --subject, and query options for alert create.'
+    )
+  }
+  const response = await AlertsService.saveAlertRule({
+    body: body as never,
+    headers: context.headers
+  })
+  printOutput(options, {
+    message: 'Alert rule created',
+    ...(unwrapApiResult(response) as Record<string, unknown>)
+  })
+}
+
+async function runAlertUpdate(ruleId: string, options: AlertOptions) {
+  const context = createApiContext(options)
+  const body = await normalizeAlertRuleBody(loadJsonInput(options))
+  if (!body) {
+    throw new CliError('Provide --file or --stdin for alert update.')
+  }
+  const response = await AlertsService.saveAlertRule2({
+    path: {
+      id: ruleId
+    },
+    body: body as never,
+    headers: context.headers
+  })
+  printOutput(options, {
+    message: `Alert rule updated: ${ruleId}`,
+    ...(unwrapApiResult(response) as Record<string, unknown>)
+  })
+}
+
+async function runAlertDelete(ruleId: string, options: AlertOptions) {
+  const context = createApiContext(options)
+  const response = await AlertsService.deleteAlertRule({
+    path: {
+      id: ruleId
+    },
+    headers: context.headers
+  })
+  printOutput(options, {
+    message: `Alert rule deleted: ${ruleId}`,
+    ...(unwrapApiResult(response) as Record<string, unknown>)
+  })
+}
+
+async function normalizeAlertRuleBody(
+  body: unknown | undefined,
+  options?: AlertOptions,
+  context?: ReturnType<typeof createApiContext>
+): Promise<AlertRuleBody | undefined> {
+  if (!body || typeof body !== 'object') {
+    return undefined
+  }
+
+  const objectBody = body as Record<string, unknown>
+  const normalizedBody: AlertRuleBody =
+    'rule' in objectBody ? (objectBody as AlertRuleBody) : { rule: objectBody as AlertRuleBody['rule'] }
+
+  if (options && context && normalizedBody.rule && !normalizedBody.rule.projectId) {
+    return await injectProjectId(normalizedBody, options, context)
+  }
+
+  return normalizedBody
+}
+
+async function injectProjectId(
+  body: AlertRuleBody,
+  options: AlertOptions,
+  context: ReturnType<typeof createApiContext>
+) {
+  const project = await resolveProjectRef(options, context, { projectId: true })
+  return {
+    ...body,
+    rule: {
+      ...body.rule,
+      projectId: project.projectId
+    }
+  }
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
+    .option('--owner <owner>', 'Sentio project owner')
+    .option('--name <name>', 'Sentio project name')
+    .option('--project-id <id>', 'Sentio project id')
+}
+
+function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--file <path>', 'Read request JSON or YAML from file')
+    .option('--stdin', 'Read request JSON or YAML from stdin')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
+}
+
+function handleAlertCommandError(error: unknown, command?: Command) {
+  if (
+    error instanceof CliError &&
+    (error.message.startsWith('Project is required.') ||
+      error.message.startsWith('Provide --file or --stdin for alert ') ||
+      error.message.startsWith('Provide --file, --stdin, or inline alert flags like') ||
+      error.message.startsWith('Alert type is required.') ||
+      error.message.startsWith('Subject is required.') ||
+      error.message.startsWith('LOG alerts require ') ||
+      error.message.startsWith('SQL alerts require ') ||
+      error.message.startsWith('METRIC alerts require ') ||
+      error.message.startsWith('Use exactly one of --event or --metric') ||
+      error.message.startsWith('Invalid alert type ') ||
+      error.message.startsWith('Invalid alert operator ') ||
+      error.message.startsWith('Invalid SQL aggregation ') ||
+      error.message.startsWith('Invalid duration ') ||
+      error.message.startsWith('Invalid project '))
+  ) {
+    console.error(error.message)
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function printOutput(options: AlertOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+  if (options.yaml) {
+    console.log(yaml.stringify(data).trimEnd())
+    return
+  }
+  console.log(formatOutput(data))
+}
+
+function formatOutput(data: unknown) {
+  if (data && typeof data === 'object' && Array.isArray((data as { rules?: unknown[] }).rules)) {
+    const objectData = data as {
+      rules: Array<Record<string, unknown>>
+      alertsByRule?: Record<string, Array<Record<string, unknown>>>
+      recentCount?: number
+    }
+    const rules = objectData.rules
+    const lines = [`Alert rules (${rules.length})`]
+    for (const rule of rules) {
+      lines.push(...formatRuleBlock(rule))
+      const ruleId = asString(rule.id) ?? ''
+      const alerts = objectData.alertsByRule?.[ruleId] ?? []
+      if (alerts.length > 0) {
+        lines.push(`  recent alerts (${Math.min(alerts.length, objectData.recentCount ?? alerts.length)})`)
+        for (const alert of alerts) {
+          lines.push(`  ${formatAlertLine(alert)}`)
+        }
+      }
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'alertRule' in (data as Record<string, unknown>)) {
+    const objectData = data as { alertRule?: Record<string, unknown>; alerts?: Array<Record<string, unknown>> }
+    const lines = ['Alert rule']
+    if (objectData.alertRule) {
+      lines.push(...formatRuleBlock(objectData.alertRule))
+    }
+    const alerts = Array.isArray(objectData.alerts) ? objectData.alerts : []
+    lines.push(`Alerts (${alerts.length})`)
+    for (const alert of alerts.slice(0, 10)) {
+      lines.push(formatAlertLine(alert))
+    }
+    if (alerts.length > 10) {
+      lines.push(`... ${alerts.length - 10} more alerts`)
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'message' in (data as Record<string, unknown>)) {
+    return asString((data as Record<string, unknown>).message) ?? JSON.stringify(data, null, 2)
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
+function formatRuleLine(rule: Record<string, unknown>) {
+  const id = asString(rule.id) ?? '<rule>'
+  const alertType = asString(rule.alertType) ?? 'UNKNOWN'
+  const state = asString(rule.state) ?? 'UNKNOWN'
+  const subject = asString(rule.subject) ?? ''
+  const mute = typeof rule.mute === 'boolean' ? (rule.mute ? ' muted' : '') : ''
+  return `- ${id} [${alertType}] state=${state}${mute}${subject ? ` subject="${subject}"` : ''}`
+}
+
+function formatRuleBlock(rule: Record<string, unknown>) {
+  const title = asString(rule.subject) ?? asString(rule.group) ?? asString(rule.id) ?? '<rule>'
+  const id = asString(rule.id) ?? '<rule>'
+  const alertType = asString(rule.alertType) ?? 'UNKNOWN'
+  const state = asString(rule.state) ?? 'UNKNOWN'
+  const mute = typeof rule.mute === 'boolean' ? (rule.mute ? ' muted' : '') : ''
+  return [`- ${title}`, `  id=${id} [${alertType}] state=${state}${mute}`]
+}
+
+function formatAlertLine(alert: Record<string, unknown>) {
+  const lastState = alert.lastState as Record<string, unknown> | undefined
+  const createState = alert.createState as Record<string, unknown> | undefined
+  const title =
+    asString(lastState?.message) ??
+    asString(createState?.message) ??
+    asString(lastState?.subject) ??
+    asString(createState?.subject) ??
+    '<alert>'
+  const state = asString(lastState?.state) ?? asString(createState?.state) ?? 'UNKNOWN'
+  const active = typeof alert.active === 'boolean' ? (alert.active ? 'active' : 'inactive') : ''
+  const time = asString(alert.startTime) ?? asString(lastState?.time) ?? asString(createState?.time) ?? ''
+  return `- ${title} [${state}]${active ? ` ${active}` : ''}${time ? ` at ${time}` : ''}`
+}
+
+function parseInteger(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}
+
+function parseNumber(value: string) {
+  const parsedValue = Number.parseFloat(value)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}
+
+function collectOption(value: string, previous: string[] = []) {
+  previous.push(value)
+  return previous
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}
+
+async function buildAlertCreateBodyFromOptions(
+  options: AlertCreateOptions,
+  context: ReturnType<typeof createApiContext>
+): Promise<AlertRuleBody | undefined> {
+  if (!options.type && !options.subject && !options.query && !options.event && !options.metric) {
+    return undefined
+  }
+
+  const project = await resolveProjectRef(options, context, { projectId: true })
+  return buildAlertRuleBodyFromSpec(
+    {
+      type: options.type,
+      subject: options.subject,
+      message: options.message,
+      query: options.query,
+      event: options.event,
+      metric: options.metric,
+      alias: options.alias,
+      sourceName: options.sourceName,
+      filter: options.filter,
+      groupBy: options.groupBy,
+      aggr: options.aggr,
+      func: options.func,
+      op: options.op,
+      threshold: options.threshold,
+      threshold2: options.threshold2,
+      for: options.for,
+      interval: options.interval,
+      timeColumn: options.timeColumn,
+      valueColumn: options.valueColumn,
+      sqlAggr: options.sqlAggr,
+      projectId: project.projectId
+    },
+    options,
+    context
+  )
+}
+
+export async function buildAlertRuleBodyFromSpec(
+  body: Record<string, unknown>,
+  options?: AlertOptions,
+  context?: ReturnType<typeof createApiContext>
+): Promise<AlertRuleBody> {
+  const alertType = normalizeAlertType(body.type)
+  const subject = asString(body.subject)?.trim()
+  if (!subject) {
+    throw new CliError('Subject is required.')
+  }
+
+  const projectId =
+    asString(body.projectId) ??
+    (options && context ? (await resolveProjectRef(options, context, { projectId: true })).projectId : undefined)
+
+  const rule: Record<string, unknown> = {
+    projectId,
+    subject,
+    message: asString(body.message),
+    alertType
+  }
+
+  const forDuration = parseDurationInput(body.for)
+  if (forDuration) {
+    rule.for = forDuration
+  }
+
+  const intervalDuration = parseDurationInput(body.interval)
+  if (intervalDuration) {
+    rule.interval = intervalDuration
+  }
+
+  switch (alertType) {
+    case 'LOG': {
+      const query = asString(body.query)?.trim()
+      if (!query) {
+        throw new CliError('LOG alerts require --query or a YAML/JSON `query` field.')
+      }
+      rule.logCondition = {
+        query,
+        comparisonOp: normalizeAlertOperator(body.op),
+        threshold: requireThreshold(body.threshold, 'LOG alerts require --threshold or a YAML/JSON `threshold` field.'),
+        threshold2: asNumber(body.threshold2)
+      }
+      break
+    }
+    case 'SQL': {
+      const query = asString(body.query)?.trim()
+      if (!query) {
+        throw new CliError('SQL alerts require --query or a YAML/JSON `query` field.')
+      }
+      rule.query = query
+      rule.sqlCondition = {
+        sqlQuery: query
+      }
+      const valueColumn = asString(body.valueColumn)
+      const timeColumn = asString(body.timeColumn)
+      const op = normalizeAlertOperator(body.op, true)
+      const threshold = asNumber(body.threshold)
+      if (
+        valueColumn ||
+        timeColumn ||
+        op ||
+        threshold !== undefined ||
+        body.sqlAggr !== undefined ||
+        body.threshold2 !== undefined
+      ) {
+        if (!valueColumn || !timeColumn || !op || threshold === undefined) {
+          throw new CliError(
+            'SQL alerts require --value-column, --time-column, --op, and --threshold for inline column conditions.'
+          )
+        }
+        ;(rule.sqlCondition as Record<string, unknown>).columnCondition = {
+          valueColumn,
+          timeColumn,
+          comparisonOp: op,
+          threshold,
+          threshold2: asNumber(body.threshold2),
+          aggregation: normalizeSqlAggregation(body.sqlAggr)
+        }
+      }
+      break
+    }
+    case 'METRIC': {
+      const querySpecs = normalizeAlertQuerySpecs(body)
+      if (querySpecs.length === 0) {
+        throw new CliError('METRIC alerts require --metric or --event, or a YAML/JSON `queries` section.')
+      }
+      if (querySpecs.length > 1 && !asString(body.formula)?.trim()) {
+        throw new CliError('Metric alert YAML with multiple queries requires a `formula` field.')
+      }
+      rule.condition = {
+        insightQueries: querySpecs.map((querySpec, index) => buildConditionInsightQuery(querySpec, index)),
+        comparisonOp: normalizeAlertOperator(body.op),
+        threshold: requireThreshold(
+          body.threshold,
+          'METRIC alerts require --threshold or a YAML/JSON `threshold` field.'
+        ),
+        threshold2: asNumber(body.threshold2)
+      }
+      const formula = normalizeFormula(body.formula)
+      if (formula) {
+        ;(rule.condition as Record<string, unknown>).formula = formula
+      }
+      break
+    }
+  }
+
+  return { rule: rule as AlertRuleBody['rule'] }
+}
+
+function normalizeAlertQuerySpecs(body: Record<string, unknown>) {
+  if (Array.isArray(body.queries)) {
+    return body.queries.map((entry) => normalizeAlertQuerySpec(entry))
+  }
+
+  if (body.metric || body.event) {
+    return [normalizeAlertQuerySpec(body)]
+  }
+
+  return []
+}
+
+function normalizeAlertQuerySpec(value: unknown): AlertQuerySpec {
+  if (!value || typeof value !== 'object') {
+    throw new CliError('Each metric alert query must be an object.')
+  }
+  const spec = value as Record<string, unknown>
+  return {
+    id: asString(spec.id),
+    event: asString(spec.event),
+    metric: asString(spec.metric),
+    alias: asString(spec.alias),
+    sourceName: asString(spec.sourceName),
+    filter: normalizeMaybeStringList(spec.filter),
+    groupBy: normalizeMaybeStringList(spec.groupBy),
+    aggr: asString(spec.aggr),
+    func: normalizeMaybeStringList(spec.func)
+  }
+}
+
+function buildConditionInsightQuery(spec: AlertQuerySpec, index: number) {
+  if (spec.event && spec.metric) {
+    throw new CliError('Use exactly one of --event or --metric for METRIC alerts.')
+  }
+  if (!spec.event && !spec.metric) {
+    throw new CliError('METRIC alert queries require exactly one of `event` or `metric`.')
+  }
+
+  const queryId = spec.id ?? defaultQueryId(index)
+
+  if (spec.metric) {
+    const queryBody = buildMetricsInsightQueryBody(spec.metric, {
+      alias: spec.alias,
+      sourceName: spec.sourceName,
+      filter: normalizeMaybeStringList(spec.filter),
+      groupBy: normalizeMaybeStringList(spec.groupBy),
+      aggr: spec.aggr,
+      func: normalizeMaybeStringList(spec.func)
+    })
+    const query = {
+      ...(queryBody.queries?.[0] as { metricsQuery?: Record<string, unknown> })?.metricsQuery,
+      id: queryId
+    }
+    return {
+      metricsQuery: query,
+      sourceName: spec.sourceName ?? ''
+    }
+  }
+
+  const queryBody = buildEventsInsightQueryBody(spec.event!, {
+    alias: spec.alias,
+    sourceName: spec.sourceName,
+    filter: normalizeMaybeStringList(spec.filter),
+    groupBy: normalizeMaybeStringList(spec.groupBy),
+    aggr: spec.aggr,
+    func: normalizeMaybeStringList(spec.func)
+  })
+  const query = { ...(queryBody.queries?.[0] as { eventsQuery?: Record<string, unknown> })?.eventsQuery, id: queryId }
+  return {
+    eventsQuery: query,
+    sourceName: spec.sourceName ?? ''
+  }
+}
+
+function normalizeAlertType(value: unknown) {
+  const normalized = asString(value)?.trim().toUpperCase()
+  if (!normalized) {
+    throw new CliError('Alert type is required. Use --type METRIC, LOG, or SQL.')
+  }
+  if (normalized === 'METRIC' || normalized === 'LOG' || normalized === 'SQL') {
+    return normalized
+  }
+  throw new CliError(`Invalid alert type "${String(value)}". Use METRIC, LOG, or SQL.`)
+}
+
+function normalizeAlertOperator(value: unknown, optional = false) {
+  const normalized = asString(value)?.trim()
+  if (!normalized) {
+    if (optional) {
+      return undefined
+    }
+    throw new CliError('Invalid alert operator "". Use one of >, >=, ==, !=, <, <=, or between.')
+  }
+  if (['>', '>=', '==', '!=', '<', '<=', 'between'].includes(normalized)) {
+    return normalized
+  }
+  throw new CliError(`Invalid alert operator "${normalized}". Use one of >, >=, ==, !=, <, <=, or between.`)
+}
+
+function normalizeSqlAggregation(value: unknown) {
+  const normalized = asString(value)?.trim().toUpperCase() ?? 'MAX'
+  if (['COUNT', 'SUM', 'AVG', 'MAX', 'MIN', 'LAST'].includes(normalized)) {
+    return normalized
+  }
+  throw new CliError(`Invalid SQL aggregation "${String(value)}". Use COUNT, SUM, AVG, MAX, MIN, or LAST.`)
+}
+
+function normalizeFormula(value: unknown) {
+  if (!value) {
+    return undefined
+  }
+  if (typeof value === 'string') {
+    return {
+      expression: value,
+      disabled: false
+    }
+  }
+  if (typeof value === 'object') {
+    return value
+  }
+  throw new CliError('Formula must be a string or object.')
+}
+
+function normalizeMaybeStringList(value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return []
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeMaybeStringList(entry))
+  }
+  throw new CliError('Expected a string or array of strings.')
+}
+
+function parseDurationInput(value: unknown) {
+  if (!value) {
+    return undefined
+  }
+  if (typeof value === 'object') {
+    return value
+  }
+  const text = asString(value)?.trim()
+  if (!text) {
+    return undefined
+  }
+  const match = /^(\d+)([a-zA-Z]+)$/.exec(text)
+  if (!match) {
+    throw new CliError(`Invalid duration "${text}". Use forms like 5m, 1h, or 7d.`)
+  }
+  return {
+    value: Number.parseInt(match[1], 10),
+    unit: match[2]
+  }
+}
+
+function requireThreshold(value: unknown, errorMessage: string) {
+  const threshold = asNumber(value)
+  if (threshold === undefined) {
+    throw new CliError(errorMessage)
+  }
+  return threshold
+}
+
+function asNumber(value: unknown) {
+  return typeof value === 'number' && !Number.isNaN(value) ? value : undefined
+}
+
+function defaultQueryId(index: number) {
+  return String.fromCharCode('a'.charCodeAt(0) + index)
+}
+
+const ALERT_CREATE_DOC = `
+Alert create file format
+
+The --file/--stdin input is passed directly to Sentio's alert create API.
+Any valid SaveAlertRuleRequest body is accepted.
+
+Supported alert types in this CLI:
+  METRIC: use rule.condition
+  LOG: use rule.logCondition
+  SQL: use rule.sqlCondition
+
+Top-level fields:
+  rule:
+    projectId: optional project id, auto-resolved when omitted
+    alertType: METRIC, LOG, or SQL
+    subject: alert title
+    message: optional alert message template
+    for: optional evaluation duration
+    interval: optional evaluation interval
+    condition: metric alert condition
+    logCondition: log alert condition
+    sqlCondition: sql alert condition
+
+Metric alert example:
+  rule:
+    alertType: METRIC
+    subject: net flow anomaly
+    message: net flow is too high
+    for:
+      value: 5
+      unit: m
+    interval:
+      value: 1
+      unit: m
+    condition:
+      comparisonOp: ">"
+      threshold: 100000
+      formula:
+        expression: a - b
+        disabled: false
+      insightQueries:
+        - metricsQuery:
+            id: a
+            alias: inflow
+            query: inflow
+            labelSelector:
+              meta.chain: "1"
+            aggregate:
+              op: SUM
+            disabled: false
+        - metricsQuery:
+            id: b
+            alias: outflow
+            query: outflow
+            labelSelector:
+              meta.chain: "1"
+            aggregate:
+              op: SUM
+            disabled: false
+
+Log alert example:
+  rule:
+    alertType: LOG
+    subject: large transfer logs
+    logCondition:
+      query: amount > 1000
+      comparisonOp: ">"
+      threshold: 0
+
+SQL alert example:
+  rule:
+    alertType: SQL
+    subject: large transfer(SQL demo)
+    query: select timestamp, amount from transfer where amount > 1000
+    sqlCondition:
+      sqlQuery: select timestamp, amount from transfer where amount > 1000
+      columnCondition:
+        timeColumn: timestamp
+        valueColumn: amount
+        aggregation: MAX
+        comparisonOp: ">"
+        threshold: 1000
+`

--- a/packages/cli/src/commands/data.test.ts
+++ b/packages/cli/src/commands/data.test.ts
@@ -1,0 +1,262 @@
+import { describe, test } from 'node:test'
+import { expect } from 'chai'
+import {
+  buildDataQueryBody,
+  buildEventsInsightQueryBody,
+  formatStructuredOutput,
+  buildMetricsInsightQueryBody,
+  buildPriceInsightQueryBody,
+  buildSqlExecuteBody,
+  buildTimeRangeLite,
+  formatDataOutput
+} from './data.js'
+
+describe('data command helpers', () => {
+  test('buildTimeRangeLite applies defaults', () => {
+    expect(buildTimeRangeLite({})).deep.equal({
+      start: 'now-7d',
+      end: 'now',
+      step: 3600,
+      timezone: undefined
+    })
+  })
+
+  test('buildEventsInsightQueryBody creates event query payload', () => {
+    const body = buildEventsInsightQueryBody('Transfer', { limit: 10, timezone: 'UTC', aggr: 'total' })
+    expect(body.queries[0].dataSource).eq('EVENTS')
+    expect((body.queries[0] as any).eventsQuery.resource.name).eq('Transfer')
+    expect(body.timeRange.timezone).eq('UTC')
+  })
+
+  test('buildMetricsInsightQueryBody creates metrics query payload', () => {
+    const body = buildMetricsInsightQueryBody('volume_total', {
+      start: 'now-1d',
+      end: 'now',
+      step: 60,
+      filter: ['chain=1'],
+      groupBy: ['token'],
+      aggr: 'avg'
+    })
+    expect(body.queries[0].dataSource).eq('METRICS')
+    expect((body.queries[0] as any).metricsQuery.query).eq('volume_total')
+    expect((body.queries[0] as any).metricsQuery.labelSelector).deep.equal({ chain: '1' })
+    expect((body.queries[0] as any).metricsQuery.aggregate).deep.equal({
+      op: 'AVG',
+      grouping: ['token']
+    })
+    expect(body.timeRange.step).eq(60)
+  })
+
+  test('buildDataQueryBody creates event query payload from flags', () => {
+    const body = buildDataQueryBody({
+      event: 'Transfer',
+      filter: ['from:0xabc', 'amount>0'],
+      groupBy: ['timestamp'],
+      aggr: 'DAU',
+      func: ['bottomk(1)', 'delta(1m)'],
+      limit: 20,
+      timezone: 'UTC'
+    })
+    expect(body).to.not.equal(undefined)
+    expect(body?.queries[0].dataSource).eq('EVENTS')
+    expect((body?.queries[0] as any).eventsQuery.resource.name).eq('Transfer')
+    expect((body?.queries[0] as any).eventsQuery.groupBy).deep.equal(['timestamp'])
+    expect((body?.queries[0] as any).eventsQuery.aggregation).deep.equal({
+      countUnique: {
+        duration: {
+          value: 1,
+          unit: 'd'
+        }
+      }
+    })
+    expect(((body?.queries[0] as any).eventsQuery.selectorExpr as any)?.logicExpr?.operator).eq('AND')
+    expect((body?.queries[0] as any).eventsQuery.functions).deep.equal([
+      {
+        name: 'bottomk',
+        arguments: [{ intValue: 1 }]
+      },
+      {
+        name: 'delta',
+        arguments: [
+          {
+            durationValue: {
+              value: 1,
+              unit: 'm'
+            }
+          }
+        ]
+      }
+    ])
+  })
+
+  test('buildDataQueryBody creates metrics query payload from flags', () => {
+    const body = buildDataQueryBody({
+      metric: 'cbETH_price',
+      filter: ['token=cbETH', 'meta.chain:1'],
+      groupBy: ['meta.address'],
+      aggr: 'max',
+      func: ['delta(1m)'],
+      limit: 20,
+      timezone: 'UTC'
+    })
+    expect(body).to.not.equal(undefined)
+    expect(body?.queries[0].dataSource).eq('METRICS')
+    expect((body?.queries[0] as any).metricsQuery.query).eq('cbETH_price')
+    expect((body?.queries[0] as any).metricsQuery.labelSelector).deep.equal({
+      token: 'cbETH',
+      'meta.chain': '1'
+    })
+    expect((body?.queries[0] as any).metricsQuery.aggregate).deep.equal({
+      op: 'MAX',
+      grouping: ['meta.address']
+    })
+    expect((body?.queries[0] as any).metricsQuery.functions).deep.equal([
+      {
+        name: 'delta',
+        arguments: [
+          {
+            durationValue: {
+              value: 1,
+              unit: 'm'
+            }
+          }
+        ]
+      }
+    ])
+  })
+
+  test('buildDataQueryBody defaults metric grouping aggregation to AVG', () => {
+    const body = buildDataQueryBody({
+      metric: 'burn',
+      groupBy: ['chain']
+    })
+    expect((body?.queries[0] as any).metricsQuery.aggregate).deep.equal({
+      op: 'AVG',
+      grouping: ['chain']
+    })
+  })
+
+  test('buildPriceInsightQueryBody creates price query payload', () => {
+    const body = buildPriceInsightQueryBody(['ETH', '1:0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2'], {
+      start: 'now-1d',
+      end: 'now',
+      step: 300
+    })
+    expect(body.queries[0].dataSource).eq('PRICE')
+    expect((body.queries[0] as any).priceQuery.coinId).deep.equal([
+      { symbol: 'ETH' },
+      {
+        address: {
+          chain: '1',
+          address: '0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2'
+        }
+      }
+    ])
+  })
+
+  test('buildDataQueryBody creates price query payload from flags', () => {
+    const body = buildDataQueryBody({
+      price: ['ETH'],
+      alias: 'ETH'
+    })
+    expect(body?.queries[0].dataSource).eq('PRICE')
+    expect((body?.queries[0] as any).priceQuery).deep.include({
+      id: 'price',
+      alias: 'ETH'
+    })
+  })
+
+  test('buildSqlExecuteBody includes cache policy and engine', () => {
+    const body = buildSqlExecuteBody({
+      query: 'select 1',
+      noCache: true,
+      cacheTtlSecs: 60,
+      cacheRefreshTtlSecs: 10,
+      engine: 'CLICKHOUSE'
+    })
+    expect(body.sqlQuery).deep.equal({
+      sql: 'select 1'
+    })
+    expect(body.cachePolicy).deep.equal({
+      noCache: true,
+      cacheTtlSecs: 60,
+      cacheRefreshTtlSecs: 10
+    })
+    expect(body.engine).eq('CLICKHOUSE')
+  })
+
+  test('formatDataOutput formats events list', () => {
+    const output = formatDataOutput({
+      events: [
+        {
+          name: 'Transfer',
+          displayName: 'Transfer',
+          properties: [
+            { name: 'amount', type: 'NUMBER' },
+            { name: 'from', type: 'STRING' }
+          ]
+        },
+        { name: 'Approval', displayName: 'Approval', properties: [{ name: 'owner', type: 'STRING' }] }
+      ]
+    })
+    expect(output).contains('Events (2)')
+    expect(output).contains('- Transfer')
+    expect(output).contains('   properties: amount(NUMBER), from')
+    expect(output).contains('- Approval')
+    expect(output).contains('   properties: owner')
+  })
+
+  test('formatDataOutput formats query results as series tables', () => {
+    const output = formatDataOutput({
+      results: [
+        {
+          alias: 'cbETH_price',
+          dataSource: 'METRICS',
+          matrix: {
+            samples: [
+              {
+                metric: { displayName: 'cbETH_price', labels: { token: 'cbETH' } },
+                values: [
+                  { timestamp: '1773194400', value: 2288.89 },
+                  { timestamp: '1773198000', value: 2291.15 }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    })
+    expect(output).contains('cbETH_price [METRICS]')
+    expect(output).contains('  - cbETH_price {token=cbETH}')
+    expect(output).contains('timestamp')
+    expect(output).contains('value')
+    expect(output).contains('2026-03-11T02:00:00.000Z')
+    expect(output).contains('2288.89')
+    expect(output).contains('2291.15')
+  })
+
+  test('formatDataOutput formats SQL result tables', () => {
+    const output = formatDataOutput({
+      runtimeCost: '209',
+      result: {
+        columns: ['v'],
+        rows: [{ v: 1 }]
+      }
+    })
+    expect(output).contains('Runtime cost: 209 ms')
+    expect(output).contains('v')
+    expect(output).contains('1')
+  })
+
+  test('formatStructuredOutput formats yaml', () => {
+    const output = formatStructuredOutput(
+      {
+        events: [{ name: 'Transfer', properties: [{ name: 'amount', type: 'NUMBER' }] }]
+      },
+      'yaml'
+    )
+    expect(output).contains('events:')
+    expect(output).contains('name: Transfer')
+    expect(output).contains('type: NUMBER')
+  })
+})

--- a/packages/cli/src/commands/data.ts
+++ b/packages/cli/src/commands/data.ts
@@ -1,0 +1,1249 @@
+import { DataService } from '@sentio/api'
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings'
+import chalk from 'chalk'
+import process from 'process'
+import yaml from 'yaml'
+import {
+  ApiContext,
+  ApiResult,
+  CliError,
+  createApiContext,
+  fetchApiJson,
+  handleCommandError,
+  loadJsonInput,
+  unwrapApiResult,
+  resolveProjectRef
+} from '../api.js'
+
+const DEFAULT_RANGE_STEP = 3600
+interface CommonDataOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+  file?: string
+  stdin?: boolean
+  json?: boolean
+  yaml?: boolean
+}
+
+interface RangeOptions {
+  start?: string
+  end?: string
+  step?: number
+  timezone?: string
+  limit?: number
+  offset?: number
+  version?: number
+}
+
+interface DataQueryOptions extends CommonDataOptions, RangeOptions {
+  doc?: boolean
+  event?: string
+  metric?: string
+  price?: string[]
+  alias?: string
+  sourceName?: string
+  filter?: string[]
+  groupBy?: string[]
+  aggr?: string
+  func?: string[]
+}
+
+interface SqlCommandOptions extends CommonDataOptions {
+  query?: string
+  result?: string
+  cursor?: string
+  async?: boolean
+  version?: number
+  engine?: string
+  noCache?: boolean
+  cacheTtlSecs?: number
+  cacheRefreshTtlSecs?: number
+}
+
+export function createDataCommand() {
+  const dataCommand = new Command('data').description('Retrieve data from Sentio')
+  dataCommand.addCommand(createDataQueryCommand())
+  dataCommand.addCommand(createDataEventsCommand())
+  dataCommand.addCommand(createDataMetricsCommand())
+  dataCommand.addCommand(createDataSqlCommand())
+  return dataCommand
+}
+
+export function buildTimeRangeLite(options: RangeOptions) {
+  return {
+    start: options.start ?? 'now-7d',
+    end: options.end ?? 'now',
+    step: options.step ?? DEFAULT_RANGE_STEP,
+    timezone: options.timezone
+  }
+}
+
+export function buildEventsInsightQueryBody(
+  search: string,
+  options: RangeOptions & {
+    alias?: string
+    sourceName?: string
+    filter?: string[]
+    groupBy?: string[]
+    aggr?: string
+    func?: string[]
+  }
+) {
+  return {
+    timeRange: buildTimeRangeLite(options),
+    limit: options.limit,
+    offset: options.offset,
+    version: options.version,
+    queries: [
+      {
+        dataSource: 'EVENTS',
+        sourceName: options.sourceName ?? '',
+        eventsQuery: {
+          id: 'events',
+          alias: options.alias ?? search,
+          resource: {
+            type: 'EVENTS',
+            name: search
+          },
+          aggregation: buildEventAggregation(options.aggr),
+          selectorExpr: buildSelectorExpr(options.filter),
+          groupBy: normalizeListOption(options.groupBy),
+          functions: buildFunctions(options.func),
+          disabled: false
+        }
+      }
+    ],
+    formulas: []
+  }
+}
+
+export function buildMetricsInsightQueryBody(
+  query: string,
+  options: RangeOptions & {
+    alias?: string
+    sourceName?: string
+    filter?: string[]
+    groupBy?: string[]
+    aggr?: string
+    func?: string[]
+  }
+) {
+  return {
+    timeRange: buildTimeRangeLite(options),
+    limit: options.limit,
+    offset: options.offset,
+    version: options.version,
+    queries: [
+      {
+        dataSource: 'METRICS',
+        sourceName: options.sourceName ?? '',
+        metricsQuery: {
+          id: 'metrics',
+          alias: options.alias ?? query,
+          query,
+          labelSelector: buildMetricLabelSelector(options.filter),
+          aggregate: buildMetricAggregate(options.aggr, options.groupBy),
+          functions: buildFunctions(options.func),
+          disabled: false
+        }
+      }
+    ],
+    formulas: []
+  }
+}
+
+export function buildPriceInsightQueryBody(
+  prices: string[],
+  options: RangeOptions & {
+    alias?: string
+    sourceName?: string
+  }
+) {
+  const normalizedPrices = normalizeListOption(prices)
+  if (normalizedPrices.length === 0) {
+    throw new CliError('Price query requires at least one coin id.')
+  }
+
+  return {
+    timeRange: buildTimeRangeLite(options),
+    limit: options.limit,
+    offset: options.offset,
+    version: options.version,
+    queries: [
+      {
+        dataSource: 'PRICE',
+        sourceName: options.sourceName ?? '',
+        priceQuery: {
+          id: 'price',
+          alias: options.alias ?? normalizedPrices.join(','),
+          coinId: normalizedPrices.map(parseCoinIdentifier),
+          disabled: false
+        }
+      }
+    ],
+    formulas: []
+  }
+}
+
+export function buildDataQueryBody(options: DataQueryOptions) {
+  const selectedKinds = [
+    Boolean(options.event),
+    Boolean(options.metric),
+    normalizeListOption(options.price).length > 0
+  ].filter(Boolean).length
+
+  if (selectedKinds > 1) {
+    throw new CliError('Use exactly one of --event, --metric, or --price for data query.')
+  }
+
+  const priceValues = normalizeListOption(options.price)
+  if (priceValues.length > 0) {
+    if (
+      normalizeListOption(options.filter).length > 0 ||
+      normalizeListOption(options.groupBy).length > 0 ||
+      options.aggr ||
+      normalizeListOption(options.func).length > 0
+    ) {
+      throw new CliError('Price queries only support --price, --alias, --source-name, and time range options.')
+    }
+    return buildPriceInsightQueryBody(priceValues, options)
+  }
+
+  if (options.metric) {
+    return buildMetricsInsightQueryBody(options.metric, options)
+  }
+
+  if (!options.event) {
+    return undefined
+  }
+
+  return buildEventsInsightQueryBody(options.event, options)
+}
+
+export function buildSqlExecuteBody(options: SqlCommandOptions) {
+  const cachePolicy =
+    options.noCache || options.cacheTtlSecs !== undefined || options.cacheRefreshTtlSecs !== undefined
+      ? {
+          noCache: options.noCache ?? false,
+          cacheTtlSecs: options.cacheTtlSecs,
+          cacheRefreshTtlSecs: options.cacheRefreshTtlSecs
+        }
+      : undefined
+
+  const body: Record<string, unknown> = {
+    version: options.version,
+    cursor: options.cursor,
+    sqlQuery: {
+      sql: options.query
+    }
+  }
+
+  if (cachePolicy) {
+    body.cachePolicy = cachePolicy
+  }
+  if (options.engine) {
+    body.engine = options.engine
+  }
+  return body
+}
+
+function createDataEventsCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('events').description('List available events for a project')))
+  )
+    .option('--version <version>', 'Processor version', parseInteger)
+    .action(async (options, command) => {
+      try {
+        await runEventsList(options)
+      } catch (error) {
+        handleDataCommandError(error, command)
+      }
+    })
+}
+
+function createDataQueryCommand() {
+  return withOutputOptions(
+    withQueryInputOptions(
+      withSharedProjectOptions(withAuthOptions(new Command('query').description('Query data with Sentio insights')))
+    )
+  )
+    .option('--doc', 'Print the full insights query file format and exit')
+    .option('--event <name>', 'Event name to query when not using --file/--stdin')
+    .option('--metric <name>', 'Metric name to query when not using --file/--stdin')
+    .option('--price <coin>', 'Coin id for a price query, for example ETH or 1:0xabc...', collectOption, [])
+    .option('--alias <alias>', 'Alias for generated query')
+    .option('--source-name <name>', 'Optional source name for generated query')
+    .option(
+      '--filter <selector>',
+      'Event filter or metric label selector like field:value or chain=1',
+      collectOption,
+      []
+    )
+    .option('--group-by <field>', 'Group by event property or metric label', collectOption, [])
+    .option('--aggr <aggregation>', 'Event: total|unique|AAU|DAU|WAU|MAU. Metric: avg|sum|min|max|count')
+    .option('--func <function>', 'Function like topk(1), bottomk(1), delta(1m)', collectOption, [])
+    .option('--start <time>', 'Time range start, defaults to now-7d')
+    .option('--end <time>', 'Time range end, defaults to now')
+    .option('--step <seconds>', 'Time range step in seconds', parseInteger, DEFAULT_RANGE_STEP)
+    .option('--timezone <timezone>', 'Timezone for the query')
+    .option('--limit <count>', 'Limit rows/series returned', parseInteger)
+    .option('--offset <count>', 'Offset rows returned', parseInteger)
+    .option('--version <version>', 'Processor version', parseInteger)
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio data query --project sentio/coinbase --event Transfer --filter amount>0 --group-by timestamp --aggr total
+  $ sentio data query --project sentio/coinbase --event Transfer --filter from:0xabc --group-by meta.address --aggr unique --func 'bottomk(5)'
+  $ sentio data query --project sentio/coinbase --metric cbETH_price
+  $ sentio data query --project sentio/coinbase --metric burn --filter meta.chain=1 --aggr avg --group-by meta.address
+  $ sentio data query --project sentio/coinbase --price ETH
+  $ sentio data query --project sentio/coinbase --file query.yaml   # use --doc to show file format
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runDataQuery(options)
+      } catch (error) {
+        handleDataCommandError(error, command)
+      }
+    })
+}
+
+function createDataMetricsCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('metrics').description('List metrics metadata for a project')))
+  )
+    .option('--metric <name>', 'Filter by metric name')
+    .option('--version <version>', 'Processor version', parseInteger)
+    .action(async (options, command) => {
+      try {
+        await runMetricsList(options)
+      } catch (error) {
+        handleDataCommandError(error, command)
+      }
+    })
+}
+
+function createDataSqlCommand() {
+  return withOutputOptions(
+    withJsonInputOptions(
+      withSharedProjectOptions(withAuthOptions(new Command('sql').description('Execute Sentio SQL')))
+    )
+  )
+    .option('--query <sql>', 'Inline SQL text when not using --file/--stdin')
+    .option('--result <execution-id>', 'Fetch an async SQL execution result')
+    .option('--cursor <cursor>', 'Cursor for paginated SQL queries')
+    .option('--async', 'Execute SQL asynchronously')
+    .option('--version <version>', 'Processor version', parseInteger)
+    .option('--engine <engine>', 'Optional SQL engine override')
+    .option('--no-cache', 'Disable cache for this SQL execution')
+    .option('--cache-ttl-secs <seconds>', 'Cache TTL in seconds', parseInteger)
+    .option('--cache-refresh-ttl-secs <seconds>', 'Cache refresh TTL in seconds', parseInteger)
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio data sql --project sentio/coinbase --query "select 1 as v"
+  $ sentio data sql --project sentio/coinbase --query "select * from transfer limit 10" --async
+  $ sentio data sql --project sentio/coinbase --result <execution-id>
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runSql(options)
+      } catch (error) {
+        handleDataCommandError(error, command)
+      }
+    })
+}
+
+async function runEventsList(
+  options: CommonDataOptions & {
+    start?: string
+    end?: string
+    timezone?: string
+    limit?: number
+    offset?: number
+    version?: number
+    search?: string
+  }
+) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: false, projectId: true })
+  const data = await fetchApiJson<{
+    events?: Array<{ name?: string; displayName?: string; properties?: Array<{ name?: string; type?: string }> }>
+    computeStats?: Record<string, unknown> | null
+  }>('/api/v1/analytics/events', context, {
+    projectId: project.projectId,
+    version: options.version
+  })
+  printOutput(options, data)
+}
+
+async function runDataQuery(options: DataQueryOptions) {
+  if (options.doc) {
+    console.log(DATA_QUERY_DOC.trimEnd())
+    return
+  }
+
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const body = loadJsonInput(options) ?? buildDataQueryBody(options)
+
+  if (!body) {
+    throw new CliError('Provide --file, --stdin, or exactly one of --event, --metric, or --price for data query.')
+  }
+
+  const response = await DataService.query({
+    path: {
+      owner: project.owner,
+      slug: project.slug
+    },
+    body: body as never,
+    headers: context.headers
+  })
+  const data = unwrapApiResult(response)
+  printOutput(options, data)
+}
+
+async function runMetricsList(options: CommonDataOptions & { metric?: string; version?: number }) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: false, projectId: true })
+  const response = await DataService.getMetrics({
+    query: {
+      projectId: project.projectId,
+      name: options.metric,
+      version: options.version
+    },
+    headers: context.headers
+  })
+  const data = unwrapApiResult(response)
+
+  printOutput(options, data)
+}
+
+async function runSql(options: SqlCommandOptions) {
+  if (options.query && options.result) {
+    throw new CliError('Use only one of --query or --result.')
+  }
+  if (options.result) {
+    if (options.async) {
+      throw new CliError('--async only works with --query.')
+    }
+    await runSqlResult(options.result, options)
+    return
+  }
+
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const body = loadJsonInput(options) ?? (options.query ? buildSqlExecuteBody(options) : undefined)
+
+  if (!body) {
+    throw new CliError('Provide --query, --result, --file, or --stdin.')
+  }
+
+  if (options.async) {
+    const response = await DataService.executeSqlAsync({
+      path: {
+        owner: project.owner,
+        slug: project.slug
+      },
+      body: body as never,
+      headers: context.headers
+    })
+    const data = unwrapApiResult(response)
+    printOutput(options, data)
+    return
+  }
+
+  const response = await DataService.executeSql({
+    path: {
+      owner: project.owner,
+      slug: project.slug
+    },
+    body: body as never,
+    headers: context.headers
+  })
+  const data = unwrapApiResult(response)
+  printOutput(options, data)
+}
+
+async function runSqlResult(executionId: string, options: CommonDataOptions & { projectId?: string }) {
+  await runSqlExecutionRead(executionId, options, (project, context) =>
+    DataService.querySqlResult({
+      path: {
+        owner: project.owner,
+        slug: project.slug,
+        executionId
+      },
+      query: {
+        projectId: project.projectId
+      },
+      headers: context.headers
+    })
+  )
+}
+
+async function runSqlExecutionRead(
+  executionId: string,
+  options: CommonDataOptions & { projectId?: string },
+  operation: (
+    project: Awaited<ReturnType<typeof resolveProjectRef>>,
+    context: ApiContext
+  ) => Promise<ApiResult<unknown>>
+) {
+  if (!executionId) {
+    throw new CliError('Execution id is required.')
+  }
+
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const data = unwrapApiResult(await operation(project, context))
+  printOutput(options, data)
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
+    .option('--owner <owner>', 'Sentio project owner')
+    .option('--name <name>', 'Sentio project name')
+    .option('--project-id <id>', 'Sentio project id')
+}
+
+function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--file <path>', 'Read request JSON or YAML from file')
+    .option('--stdin', 'Read request JSON or YAML from stdin')
+}
+
+function withQueryInputOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--file <path>', 'Read request JSON or YAML from file. Use --doc to show the full insight query format')
+    .option('--stdin', 'Read request JSON or YAML from stdin. Use --doc to show the full insight query format')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .showHelpAfterError()
+    .option('--json', 'Print raw JSON response')
+    .option('--yaml', 'Print raw YAML response')
+}
+
+function parseInteger(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}
+
+function collectOption(value: string, previous: string[] = []) {
+  previous.push(value)
+  return previous
+}
+
+function printJson(data: unknown) {
+  console.log(JSON.stringify(data, null, 2))
+}
+
+function handleDataCommandError(error: unknown, command?: Command) {
+  if (error instanceof CliError && shouldShowHelpForDataCommandError(error)) {
+    console.error(chalk.red(error.message))
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function shouldShowHelpForDataCommandError(error: CliError) {
+  return (
+    error.message.startsWith('Project is required.') ||
+    error.message.startsWith(
+      'Provide --file, --stdin, or exactly one of --event, --metric, or --price for data query'
+    ) ||
+    error.message.startsWith('Use exactly one of --event, --metric, or --price for data query.') ||
+    error.message.startsWith('Price queries only support --price') ||
+    error.message.startsWith('Provide --query, --result, --file, or --stdin.') ||
+    error.message.startsWith('Use only one of --query or --result.') ||
+    error.message.startsWith('--async only works with --query.') ||
+    error.message.startsWith('Execution id is required.')
+  )
+}
+
+function buildEventAggregation(aggregationName = 'total') {
+  switch (aggregationName.toUpperCase()) {
+    case 'TOTAL':
+      return { total: {} }
+    case 'UNIQUE':
+      return { unique: {} }
+    case 'AAU':
+      return { countUnique: { duration: { value: 1, unit: 'y' } } }
+    case 'DAU':
+      return { countUnique: { duration: { value: 1, unit: 'd' } } }
+    case 'WAU':
+      return { countUnique: { duration: { value: 1, unit: 'w' } } }
+    case 'MAU':
+      return { countUnique: { duration: { value: 1, unit: 'mo' } } }
+    default:
+      throw new CliError(`Invalid aggregation "${aggregationName}". Use total, unique, AAU, DAU, WAU, or MAU.`)
+  }
+}
+
+function buildMetricAggregate(aggregationName?: string, groupBy?: string[]) {
+  const grouping = normalizeListOption(groupBy)
+  if (!aggregationName && grouping.length === 0) {
+    return undefined
+  }
+
+  const normalizedAggregation = (aggregationName ?? 'avg').toUpperCase()
+  switch (normalizedAggregation) {
+    case 'AVG':
+    case 'SUM':
+    case 'MIN':
+    case 'MAX':
+    case 'COUNT':
+      return {
+        op: normalizedAggregation,
+        grouping
+      }
+    default:
+      throw new CliError(`Invalid metric aggregation "${aggregationName}". Use avg, sum, min, max, or count.`)
+  }
+}
+
+function buildMetricLabelSelector(filters?: string[]) {
+  const selectors = normalizeListOption(filters)
+  if (selectors.length === 0) {
+    return {}
+  }
+
+  return Object.fromEntries(selectors.map(parseMetricLabelSelector))
+}
+
+function buildSelectorExpr(filters?: string[]) {
+  const normalizedFilters = normalizeListOption(filters)
+  if (normalizedFilters.length === 0) {
+    return undefined
+  }
+
+  const expressions = normalizedFilters.map((filter) => {
+    const parsed = parseSelectorFilter(filter)
+    return {
+      selector: {
+        key: parsed.key,
+        operator: parsed.operator,
+        value: parsed.value
+      }
+    }
+  })
+
+  if (expressions.length === 1) {
+    return expressions[0]
+  }
+
+  return {
+    logicExpr: {
+      operator: 'AND',
+      expressions
+    }
+  }
+}
+
+function parseSelectorFilter(filter: string) {
+  const trimmed = filter.trim()
+  const operators = [
+    { token: '!=', operator: 'NEQ' },
+    { token: '>=', operator: 'GTE' },
+    { token: '<=', operator: 'LTE' },
+    { token: '>', operator: 'GT' },
+    { token: '<', operator: 'LT' },
+    { token: ':', operator: 'EQ' },
+    { token: '=', operator: 'EQ' }
+  ] as const
+
+  for (const entry of operators) {
+    const index = trimmed.indexOf(entry.token)
+    if (index <= 0) {
+      continue
+    }
+    const key = trimmed.slice(0, index).trim()
+    const rawValue = trimmed.slice(index + entry.token.length).trim()
+    if (!key || !rawValue) {
+      break
+    }
+    return {
+      key,
+      operator: entry.operator,
+      value: [parseAnyValue(rawValue)]
+    }
+  }
+
+  throw new CliError(`Invalid filter "${filter}". Use forms like field:value, field=value, amount>0, or amount>=0.`)
+}
+
+function parseMetricLabelSelector(filter: string) {
+  const trimmed = filter.trim()
+  for (const token of [':', '=']) {
+    const index = trimmed.indexOf(token)
+    if (index <= 0) {
+      continue
+    }
+    const key = trimmed.slice(0, index).trim()
+    const value = stripMatchingQuotes(trimmed.slice(index + token.length).trim())
+    if (key && value) {
+      return [key, value] as const
+    }
+  }
+
+  throw new CliError(`Invalid metric selector "${filter}". Use forms like chain:1 or token=cbETH.`)
+}
+
+function parseAnyValue(rawValue: string) {
+  const unquotedValue = stripMatchingQuotes(rawValue)
+  if (/^-?\d+$/.test(unquotedValue)) {
+    return { longValue: unquotedValue }
+  }
+  if (/^-?\d+\.\d+$/.test(unquotedValue)) {
+    return { doubleValue: Number.parseFloat(unquotedValue) }
+  }
+  if (unquotedValue === 'true' || unquotedValue === 'false') {
+    return { boolValue: unquotedValue === 'true' }
+  }
+  return { stringValue: unquotedValue }
+}
+
+function buildFunctions(functions?: string[]) {
+  return normalizeListOption(functions).map(parseFunctionCall)
+}
+
+function parseFunctionCall(value: string) {
+  const trimmed = value.trim()
+  const match = /^([a-zA-Z_][\w]*)\((.*)\)$/.exec(trimmed)
+  if (!match) {
+    return {
+      name: trimmed,
+      arguments: []
+    }
+  }
+
+  const [, name, rawArgs] = match
+  const args = rawArgs.trim() ? splitFunctionArgs(rawArgs).map(parseFunctionArgument) : []
+  return {
+    name,
+    arguments: args
+  }
+}
+
+function splitFunctionArgs(value: string) {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function parseFunctionArgument(value: string) {
+  const unquotedValue = stripMatchingQuotes(value)
+  const durationMatch = /^(-?\d+)([a-zA-Z]+)$/.exec(unquotedValue)
+  if (durationMatch) {
+    return {
+      durationValue: {
+        value: Number.parseInt(durationMatch[1], 10),
+        unit: durationMatch[2]
+      }
+    }
+  }
+  if (/^-?\d+$/.test(unquotedValue)) {
+    return { intValue: Number.parseInt(unquotedValue, 10) }
+  }
+  if (/^-?\d+\.\d+$/.test(unquotedValue)) {
+    return { doubleValue: Number.parseFloat(unquotedValue) }
+  }
+  if (unquotedValue === 'true' || unquotedValue === 'false') {
+    return { boolValue: unquotedValue === 'true' }
+  }
+  return { stringValue: unquotedValue }
+}
+
+function parseCoinIdentifier(value: string) {
+  const normalizedValue = stripMatchingQuotes(value.trim())
+  const addressMatch = /^([^:]+):(0x[a-fA-F0-9]+)$/.exec(normalizedValue)
+  if (addressMatch) {
+    return {
+      address: {
+        chain: addressMatch[1],
+        address: addressMatch[2]
+      }
+    }
+  }
+
+  return {
+    symbol: normalizedValue
+  }
+}
+
+function normalizeListOption(values?: string[]) {
+  return (values ?? [])
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+function stripMatchingQuotes(value: string) {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+const DATA_QUERY_DOC = `
+Insights query file format
+
+The --file/--stdin input is passed directly to Sentio's insights query API.
+Any valid request body for the insights query endpoint is accepted.
+
+Top-level fields:
+  version: optional processor version
+  timeRange:
+    start: relative or absolute time, for example now-7d
+    end: relative or absolute time, for example now
+    step: bucket size in seconds
+    timezone: optional timezone like UTC
+  limit: optional result limit
+  offset: optional result offset
+  queries: array of event, metric, or price queries
+  formulas: optional array of formulas that combine query ids
+
+Event query example:
+  version: 67
+  timeRange:
+    start: now-7d
+    end: now
+    step: 3600
+  queries:
+    - dataSource: EVENTS
+      sourceName: ""
+      eventsQuery:
+        id: a
+        alias: Transfer
+        resource:
+          type: EVENTS
+          name: Transfer
+        aggregation:
+          total: {}
+        selectorExpr:
+          logicExpr:
+            operator: AND
+            expressions:
+              - selector:
+                  key: amount
+                  operator: GT
+                  value:
+                    - longValue: "0"
+        groupBy:
+          - timestamp
+        functions:
+          - name: bottomk
+            arguments:
+              - intValue: 5
+        disabled: false
+  formulas: []
+
+Metric query example:
+  version: 67
+  timeRange:
+    start: now-7d
+    end: now
+    step: 3600
+  queries:
+    - dataSource: METRICS
+      sourceName: ""
+      metricsQuery:
+        id: a
+        alias: burn
+        query: burn
+        labelSelector:
+          meta.chain: "1"
+        aggregate:
+          op: AVG
+          grouping:
+            - meta.address
+        functions:
+          - name: delta
+            arguments:
+              - durationValue:
+                  value: 1
+                  unit: h
+        disabled: false
+  formulas: []
+
+Price query example:
+  timeRange:
+    start: now-7d
+    end: now
+    step: 3600
+  queries:
+    - dataSource: PRICE
+      sourceName: ""
+      priceQuery:
+        id: a
+        alias: ETH
+        coinId:
+          - symbol: ETH
+          - address:
+              chain: "1"
+              address: "0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2"
+        disabled: false
+  formulas: []
+
+Formula example:
+  formulas:
+    - id: f
+      alias: net
+      expression: a - b
+      disabled: false
+
+Reference:
+  https://docs.sentio.xyz/reference/query-1
+`
+
+export function formatStructuredOutput(data: unknown, outputFormat: 'json' | 'yaml') {
+  if (outputFormat === 'json') {
+    return JSON.stringify(data, null, 2)
+  }
+  return yaml.stringify(data)
+}
+
+export function formatDataOutput(data: unknown) {
+  if (!data || typeof data !== 'object') {
+    return String(data)
+  }
+  const objectData = data as Record<string, unknown>
+
+  if (hasEventMetadata(objectData)) {
+    const lines = [`Events (${objectData.events.length})`]
+    for (const event of objectData.events) {
+      const name = asString(event.displayName) || asString(event.name) || '<unknown>'
+      const properties = Array.isArray(event.properties) ? event.properties : []
+      lines.push(`- ${name}`)
+      if (properties.length > 0) {
+        lines.push(`   properties: ${formatEventProperties(properties)}`)
+      }
+    }
+    return lines.join('\n')
+  }
+
+  if (hasMetrics(objectData)) {
+    return formatMetricsList(objectData.metrics)
+  }
+
+  if (hasResults(objectData)) {
+    return formatInsightsResults(objectData.results)
+  }
+
+  if (isSqlExecuteResult(objectData)) {
+    const lines = []
+    if (objectData.runtimeCost) {
+      lines.push(`Runtime cost: ${objectData.runtimeCost} ms`)
+    }
+    if (objectData.result) {
+      lines.push(formatTable(objectData.result.columns ?? [], objectData.result.rows ?? []))
+    }
+    return lines.join('\n\n')
+  }
+
+  if (isSqlAsyncResult(objectData)) {
+    const lines = ['SQL query queued']
+    if (objectData.queryId) {
+      lines.push(`Query ID: ${objectData.queryId}`)
+    }
+    if (objectData.executionId) {
+      lines.push(`Execution ID: ${objectData.executionId}`)
+    }
+    if (objectData.queueLength !== undefined) {
+      lines.push(`Queue length: ${objectData.queueLength}`)
+    }
+    return lines.join('\n')
+  }
+
+  if (isSqlResultResponse(objectData)) {
+    return formatSqlExecutionInfo(objectData.executionInfo)
+  }
+
+  if (isSqlStatusResponse(objectData)) {
+    return formatComputeStats(objectData.computeStats)
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
+function printOutput(options: CommonDataOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    printJson(data)
+    return
+  }
+  if (options.yaml) {
+    console.log(formatStructuredOutput(data, 'yaml').trimEnd())
+    return
+  }
+  console.log(formatDataOutput(data))
+}
+
+function hasEventMetadata(data: Record<string, unknown>): data is {
+  events: Array<{ name?: string; displayName?: string; properties?: Array<{ name?: string; type?: string }> }>
+} {
+  return Array.isArray(data.events)
+}
+
+function hasMetrics(data: Record<string, unknown>): data is { metrics: Array<Record<string, unknown>> } {
+  return Array.isArray(data.metrics)
+}
+
+function hasResults(data: Record<string, unknown>): data is { results: Array<Record<string, unknown>> } {
+  return Array.isArray(data.results)
+}
+
+function isSqlExecuteResult(data: Record<string, unknown>): data is {
+  runtimeCost?: string
+  result?: { columns?: string[]; rows?: Array<Record<string, unknown>> }
+} {
+  return 'result' in data && typeof data.result === 'object'
+}
+
+function isSqlAsyncResult(
+  data: Record<string, unknown>
+): data is { queryId?: string; executionId?: string; queueLength?: number } {
+  return 'executionId' in data || 'queryId' in data
+}
+
+function isSqlResultResponse(data: Record<string, unknown>): data is { executionInfo?: Record<string, unknown> } {
+  return 'executionInfo' in data
+}
+
+function isSqlStatusResponse(data: Record<string, unknown>): data is { computeStats?: Record<string, unknown> } {
+  return 'computeStats' in data
+}
+
+function formatMetricsList(metrics: Array<Record<string, unknown>>) {
+  const lines = [`Metrics (${metrics.length})`]
+  for (const metric of metrics) {
+    const name = asString(metric.name) ?? '<unknown>'
+    const type = asString((metric.metadata as Record<string, unknown> | undefined)?.type) ?? 'UNKNOWN'
+    const chainId = asStringArray(metric.chainId).join(',')
+    const contract = asStringArray(metric.contractName).join(',')
+    const lastSeen = formatTimestamp((metric.metadata as Record<string, unknown> | undefined)?.lastSeen)
+    const extras = [`type=${type}`]
+    if (chainId) {
+      extras.push(`chain=${chainId}`)
+    }
+    if (contract) {
+      extras.push(`contract=${contract}`)
+    }
+    if (lastSeen) {
+      extras.push(`lastSeen=${lastSeen}`)
+    }
+    lines.push(`- ${name} (${extras.join(', ')})`)
+  }
+  return lines.join('\n')
+}
+
+function formatEventProperties(properties: Array<{ name?: string; type?: string }>) {
+  return properties
+    .map((property) => {
+      const propertyName = asString(property.name) || '<unknown>'
+      const propertyType = asString(property.type)
+      if (!propertyType || propertyType === 'STRING') {
+        return propertyName
+      }
+      return `${propertyName}(${propertyType})`
+    })
+    .join(', ')
+}
+
+function formatInsightsResults(results: Array<Record<string, unknown>>) {
+  const lines: string[] = []
+  results.forEach((result, index) => {
+    const alias = asString(result.alias) || asString(result.id) || `result-${index + 1}`
+    const source = asString(result.dataSource) ?? 'UNKNOWN'
+    const matrix = result.matrix as Record<string, unknown> | undefined
+    const samples = Array.isArray(matrix?.samples) ? (matrix.samples as Array<Record<string, unknown>>) : []
+    lines.push(`${alias} [${source}]`)
+    if (samples.length === 0) {
+      const error = asString(result.error)
+      lines.push(error ? `  error: ${error}` : '  no samples')
+      return
+    }
+    const limit = Math.min(samples.length, 5)
+    for (const sample of samples.slice(0, limit)) {
+      const metric = (sample.metric as Record<string, unknown> | undefined) ?? {}
+      const displayName = asString(metric.displayName) || asString(metric.name) || 'series'
+      const labels = formatLabels(metric.labels as Record<string, unknown> | undefined)
+      const values = Array.isArray(sample.values) ? (sample.values as Array<Record<string, unknown>>) : []
+      const seriesTitle = `${displayName}${labels ? ` {${labels}}` : ''}`
+      lines.push(`  - ${seriesTitle}`)
+      lines.push(
+        indentLines(
+          formatTable(
+            ['timestamp', 'value'],
+            values.map((value) => ({
+              timestamp: formatTimestamp(value.timestamp) ?? stringifyCell(value.timestamp),
+              value: value.value
+            }))
+          ),
+          '    '
+        )
+      )
+    }
+    if (samples.length > limit) {
+      lines.push(`  ... ${samples.length - limit} more series`)
+    }
+  })
+  return lines.join('\n')
+}
+
+function formatSqlExecutionInfo(info: Record<string, unknown> | undefined) {
+  if (!info) {
+    return 'No execution info returned.'
+  }
+  const lines: string[] = []
+  if (asString(info.executionId)) {
+    lines.push(`Execution ID: ${asString(info.executionId)}`)
+  }
+  if (asString(info.status)) {
+    lines.push(`Status: ${asString(info.status)}`)
+  }
+  if (asString(info.queryId)) {
+    lines.push(`Query ID: ${asString(info.queryId)}`)
+  }
+  if (asString(info.startedAt)) {
+    lines.push(`Started: ${asString(info.startedAt)}`)
+  }
+  if (asString(info.finishedAt)) {
+    lines.push(`Finished: ${asString(info.finishedAt)}`)
+  }
+  const result = info.result as Record<string, unknown> | undefined
+  if (result?.columns || result?.rows) {
+    lines.push('', formatTable(asStringArray(result.columns), asRecordArray(result.rows)))
+  }
+  const error = asString(info.error)
+  if (error) {
+    lines.push(`Error: ${error}`)
+  }
+  return lines.join('\n')
+}
+
+function formatComputeStats(stats: Record<string, unknown> | undefined) {
+  if (!stats) {
+    return 'No status details returned.'
+  }
+  const lines = ['Execution status']
+  if (asString(stats.computedAt)) {
+    lines.push(`Computed at: ${asString(stats.computedAt)}`)
+  }
+  if (asString(stats.computeCostMs)) {
+    lines.push(`Compute cost: ${asString(stats.computeCostMs)} ms`)
+  }
+  if (asString(stats.computedBy)) {
+    lines.push(`Computed by: ${asString(stats.computedBy)}`)
+  }
+  return lines.join('\n')
+}
+
+function formatTable(columns: string[], rows: Array<Record<string, unknown>>) {
+  if (columns.length === 0) {
+    return rows.length === 0 ? 'No rows returned.' : JSON.stringify(rows, null, 2)
+  }
+  const shownRows = rows.slice(0, 20)
+  const widths = columns.map((column) => column.length)
+  for (const row of shownRows) {
+    columns.forEach((column, index) => {
+      widths[index] = Math.max(widths[index], stringifyCell(row[column]).length)
+    })
+  }
+  const header = columns.map((column, index) => column.padEnd(widths[index])).join('  ')
+  const separator = columns.map((_, index) => '-'.repeat(widths[index])).join('  ')
+  const body = shownRows.map((row) =>
+    columns.map((column, index) => stringifyCell(row[column]).padEnd(widths[index])).join('  ')
+  )
+  if (rows.length > shownRows.length) {
+    body.push(`... ${rows.length - shownRows.length} more rows`)
+  }
+  return [header, separator, ...body].join('\n')
+}
+
+function indentLines(value: string, indent: string) {
+  return value
+    .split('\n')
+    .map((line) => `${indent}${line}`)
+    .join('\n')
+}
+
+function stringifyCell(value: unknown) {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  return JSON.stringify(value)
+}
+
+function formatLabels(labels: Record<string, unknown> | undefined) {
+  if (!labels) {
+    return ''
+  }
+  return Object.entries(labels)
+    .map(([key, value]) => `${key}=${stringifyCell(value)}`)
+    .join(', ')
+}
+
+function formatTimestamp(value: unknown) {
+  const stringValue = asString(value)
+  if (!stringValue) {
+    return undefined
+  }
+  if (/^\d+$/.test(stringValue)) {
+    const num = Number(stringValue)
+    const millis = stringValue.length <= 10 ? num * 1000 : num
+    return new Date(millis).toISOString()
+  }
+  const parsed = Date.parse(stringValue)
+  if (!Number.isNaN(parsed)) {
+    return new Date(parsed).toISOString()
+  }
+  return stringValue
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asStringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function asRecordArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object')
+    : []
+}

--- a/packages/cli/src/commands/endpoint.test.ts
+++ b/packages/cli/src/commands/endpoint.test.ts
@@ -1,0 +1,88 @@
+import { describe, test } from 'node:test'
+import { expect } from 'chai'
+import {
+  buildCurlCommand,
+  buildEndpointInvocation,
+  parseEndpointArgSchema,
+  parseEndpointArgValues,
+  toRichValueTemplate
+} from './endpoint.js'
+
+describe('endpoint command helpers', () => {
+  test('parseEndpointArgSchema maps supported types to rich value templates', () => {
+    expect(parseEndpointArgSchema('{"a":"string","b":"int","c":"datetime","d":"bool"}')).deep.equal({
+      a: { stringValue: '' },
+      b: { floatValue: 0 },
+      c: { timestampValue: '' },
+      d: { boolValue: false }
+    })
+  })
+
+  test('parseEndpointArgValues parses values as a plain object', () => {
+    expect(parseEndpointArgValues('{"min_amount":1000,"symbol":"ETH"}')).deep.equal({
+      min_amount: 1000,
+      symbol: 'ETH'
+    })
+  })
+
+  test('toRichValueTemplate rejects unsupported types', () => {
+    expect(() => toRichValueTemplate('enum')).to.throw('Unsupported argument type "enum"')
+  })
+
+  test('buildEndpointInvocation maps args into path, query, and body', () => {
+    const invocation = buildEndpointInvocation(
+      {
+        endpointUrl: 'https://endpoint.sentio.xyz/sentio/coinbase/transfers/:account',
+        method: 'POST',
+        pathParameters: [{ name: 'account', required: true }],
+        queryParameters: [{ name: 'limit' }],
+        bodyParameters: [{ name: 'min_amount' }, { name: 'symbol' }]
+      },
+      {
+        account: '0xabc',
+        limit: 10,
+        min_amount: 1000,
+        symbol: 'ETH'
+      }
+    )
+
+    expect(invocation).deep.equal({
+      method: 'POST',
+      url: 'https://endpoint.sentio.xyz/sentio/coinbase/transfers/0xabc?limit=10',
+      body: {
+        min_amount: 1000,
+        symbol: 'ETH'
+      }
+    })
+  })
+
+  test('buildCurlCommand renders placeholders for docs parameters', () => {
+    const command = buildCurlCommand({
+      endpointUrl: 'https://endpoint.sentio.xyz/sentio/coinbase/transfers/:account',
+      method: 'POST',
+      pathParameters: [{ name: 'account' }],
+      queryParameters: [{ name: 'limit' }, { name: 'cursor', required: true }],
+      bodyParameters: [{ name: 'min_amount' }]
+    })
+
+    expect(command).contains(
+      "curl 'https://endpoint.sentio.xyz/sentio/coinbase/transfers/<account>?cursor=%3Ccursor%3E'"
+    )
+    expect(command).not.contains('limit=%3Climit%3E')
+    expect(command).contains('-X POST')
+    expect(command).contains("-H 'Api-Key: <API_KEY>'")
+    expect(command).contains(`-d '{"min_amount":"<min_amount>"}'`)
+  })
+
+  test('buildEndpointInvocation falls back to POST when docs method is blank', () => {
+    const invocation = buildEndpointInvocation(
+      {
+        endpointUrl: 'https://endpoint.sentio.xyz/sentio/coinbase/recent_ts',
+        method: ''
+      },
+      {}
+    )
+
+    expect(invocation.method).eq('POST')
+  })
+})

--- a/packages/cli/src/commands/endpoint.ts
+++ b/packages/cli/src/commands/endpoint.ts
@@ -1,0 +1,655 @@
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings'
+import process from 'process'
+import yaml from 'yaml'
+import { CliError, createApiContext, fetchApiJson, handleCommandError, postApiJson, resolveProjectRef } from '../api.js'
+import { getApiUrl } from '../utils.js'
+
+interface EndpointOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+  json?: boolean
+  yaml?: boolean
+}
+
+interface EndpointCreateOptions extends EndpointOptions {
+  query?: string
+  args?: string
+  endpointName?: string
+  slug?: string
+  private?: boolean
+  version?: number
+}
+
+interface EndpointLookupOptions extends EndpointOptions {
+  id?: string
+  version?: number
+}
+
+interface EndpointTestOptions extends EndpointLookupOptions {
+  args?: string
+}
+
+interface EndpointRecord {
+  id?: string
+  name?: string
+  slug?: string
+  owner?: string
+  projectId?: string
+  projectSlug?: string
+  isPublic?: boolean
+  enabled?: boolean
+  sqlQueryId?: string
+  totalCalls?: string
+}
+
+interface EndpointDocResponse {
+  endpointUrl?: string
+  pathParameters?: EndpointParameter[]
+  bodyParameters?: EndpointParameter[]
+  queryParameters?: EndpointParameter[]
+  method?: string
+}
+
+interface EndpointParameter {
+  name?: string
+  type?: string
+  description?: string
+  required?: boolean
+}
+
+interface SqlSaveResponse {
+  queryId?: string
+}
+
+interface SqlGetResponse {
+  queryId?: string
+  sqlQuery?: {
+    sql?: string
+    parameters?: {
+      fields?: Record<string, unknown>
+    }
+    name?: string
+  }
+}
+
+export function createEndpointCommand() {
+  const endpointCommand = new Command('endpoint').description('Manage Sentio SQL endpoints')
+  endpointCommand.addCommand(createEndpointCreateCommand())
+  endpointCommand.addCommand(createEndpointGetCommand())
+  endpointCommand.addCommand(createEndpointListCommand())
+  endpointCommand.addCommand(createEndpointDeleteCommand())
+  endpointCommand.addCommand(createEndpointTestCommand())
+  return endpointCommand
+}
+
+function createEndpointCreateCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('create').description('Create a SQL endpoint')))
+  )
+    .showHelpAfterError()
+    .option('--query <sql>', 'SQL query text')
+    .option('--args <json>', 'JSON object of SQL parameter types, for example {"a":"string","b":"int"}')
+    .option('--endpoint-name <name>', 'Endpoint name')
+    .option('--slug <slug>', 'Endpoint slug')
+    .option('--private', 'Create a private endpoint')
+    .option('--version <version>', 'Processor version', parseInteger)
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio endpoint create --project sentio/coinbase --query "select * from transfer where amount > \${min_amount}" --args '{"min_amount":"int"}'
+  $ sentio endpoint create --project sentio/coinbase --query "select now()" --endpoint-name "Now" --slug now
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runEndpointCreate(options)
+      } catch (error) {
+        handleEndpointCommandError(error, command)
+      }
+    })
+}
+
+function createEndpointGetCommand() {
+  return withOutputOptions(withSharedProjectOptions(withAuthOptions(new Command('get').description('Get an endpoint'))))
+    .showHelpAfterError()
+    .requiredOption('--id <id>', 'Endpoint id')
+    .option('--version <version>', 'Processor version', parseInteger)
+    .action(async (options, command) => {
+      try {
+        await runEndpointGet(options)
+      } catch (error) {
+        handleEndpointCommandError(error, command)
+      }
+    })
+}
+
+function createEndpointListCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('list').description('List endpoints in a project')))
+  )
+    .showHelpAfterError()
+    .option('--version <version>', 'Processor version', parseInteger)
+    .action(async (options, command) => {
+      try {
+        await runEndpointList(options)
+      } catch (error) {
+        handleEndpointCommandError(error, command)
+      }
+    })
+}
+
+function createEndpointDeleteCommand() {
+  return withOutputOptions(withAuthOptions(new Command('delete').description('Delete an endpoint')))
+    .showHelpAfterError()
+    .requiredOption('--id <id>', 'Endpoint id')
+    .action(async (options, command) => {
+      try {
+        await runEndpointDelete(options)
+      } catch (error) {
+        handleEndpointCommandError(error, command)
+      }
+    })
+}
+
+function createEndpointTestCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('test').description('Call an endpoint')))
+  )
+    .showHelpAfterError()
+    .requiredOption('--id <id>', 'Endpoint id')
+    .option('--args <json>', 'JSON object of argument values')
+    .option('--version <version>', 'Processor version', parseInteger)
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio endpoint test --project sentio/coinbase --id <endpoint-id> --args '{"min_amount":1000}'
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runEndpointTest(options)
+      } catch (error) {
+        handleEndpointCommandError(error, command)
+      }
+    })
+}
+
+async function runEndpointCreate(options: EndpointCreateOptions) {
+  if (!options.query) {
+    throw new CliError('SQL query is required. Use --query <sql>.')
+  }
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true, projectId: true })
+  const argSchema = parseEndpointArgSchema(options.args)
+
+  const sqlSave = await postApiJson<SqlSaveResponse>(
+    `/api/v1/analytics/${project.owner}/${project.slug}/sql/save`,
+    context,
+    {
+      projectOwner: project.owner,
+      projectSlug: project.slug,
+      projectId: project.projectId,
+      version: options.version,
+      source: 'ENDPOINT',
+      runImmediately: false,
+      sqlQuery: {
+        sql: options.query,
+        name: options.endpointName,
+        parameters: Object.keys(argSchema).length > 0 ? { fields: argSchema } : undefined
+      }
+    }
+  )
+
+  const sqlQueryId = sqlSave.queryId
+  if (!sqlQueryId) {
+    throw new CliError('Failed to create endpoint SQL query.')
+  }
+
+  const slug = options.slug ?? sqlQueryId
+  const endpointName = options.endpointName ?? slug
+
+  const endpoint = await postApiJson<{ endpoints?: EndpointRecord[] }>('/api/v1/endpoint', context, {
+    projectId: project.projectId,
+    owner: project.owner,
+    projectSlug: project.slug,
+    name: endpointName,
+    slug,
+    sqlQueryId,
+    isPublic: options.private ? false : true,
+    enabled: true
+  })
+
+  const created = endpoint.endpoints?.[0] ?? {
+    name: endpointName,
+    slug,
+    projectId: project.projectId,
+    owner: project.owner,
+    projectSlug: project.slug,
+    sqlQueryId,
+    isPublic: options.private ? false : true,
+    enabled: true
+  }
+
+  printOutput(options, {
+    message: 'Endpoint created',
+    endpoint: created
+  })
+}
+
+async function runEndpointGet(options: EndpointLookupOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const endpoint = await fetchApiJson<EndpointRecord>(
+    `/api/v1/endpoint/${project.owner}/${project.slug}/${options.id}`,
+    context,
+    {
+      projectOwner: project.owner,
+      projectSlug: project.slug,
+      endpointId: options.id,
+      version: options.version
+    }
+  )
+  const docs = await fetchApiJson<EndpointDocResponse>(`/api/v1/endpoint/${options.id}/docs`, context, {
+    endpointId: options.id,
+    projectOwner: project.owner,
+    projectSlug: project.slug,
+    version: options.version
+  })
+  const sqlQuery = endpoint.sqlQueryId
+    ? await fetchApiJson<SqlGetResponse>(
+        `/api/v1/analytics/${project.owner}/${project.slug}/sql/get_query/${endpoint.sqlQueryId}`,
+        context,
+        {
+          projectOwner: project.owner,
+          projectSlug: project.slug,
+          projectId: endpoint.projectId,
+          version: options.version,
+          queryId: endpoint.sqlQueryId
+        }
+      )
+    : undefined
+
+  printOutput(options, {
+    endpoint,
+    docs,
+    sqlQuery
+  })
+}
+
+async function runEndpointList(options: EndpointLookupOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { projectId: true })
+  const data = await fetchApiJson<{ endpoints?: EndpointRecord[] }>(
+    `/api/v1/endpoint/${project.projectId}/endpoints`,
+    context,
+    {
+      projectId: project.projectId,
+      version: options.version
+    }
+  )
+  printOutput(options, data)
+}
+
+async function runEndpointDelete(options: EndpointLookupOptions) {
+  const context = createApiContext(options)
+  const response = await fetch(getApiUrl(`/api/v1/endpoint/${options.id}`, context.host).href, {
+    method: 'DELETE',
+    headers: context.headers
+  })
+  if (!response.ok) {
+    throw new CliError(`Failed to delete endpoint ${options.id}: ${response.status} ${response.statusText}`)
+  }
+  printOutput(options, { message: `Endpoint deleted: ${options.id}` })
+}
+
+async function runEndpointTest(options: EndpointTestOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const endpoint = await fetchApiJson<EndpointRecord>(
+    `/api/v1/endpoint/${project.owner}/${project.slug}/${options.id}`,
+    context,
+    {
+      projectOwner: project.owner,
+      projectSlug: project.slug,
+      endpointId: options.id,
+      version: options.version
+    }
+  )
+  const docs = await fetchApiJson<EndpointDocResponse>(`/api/v1/endpoint/${options.id}/docs`, context, {
+    endpointId: options.id,
+    projectOwner: project.owner,
+    projectSlug: project.slug,
+    version: options.version
+  })
+
+  const inputArgs = parseEndpointArgValues(options.args)
+  const request = buildEndpointInvocation(docs, inputArgs)
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (context.headers['api-key']) {
+    headers['Api-Key'] = context.headers['api-key']
+  } else if (context.headers.Authorization) {
+    headers.Authorization = context.headers.Authorization
+  }
+
+  const response = await fetch(request.url, {
+    method: request.method,
+    headers,
+    body: request.method === 'GET' ? undefined : JSON.stringify(request.body)
+  })
+  const text = await response.text()
+  let payload: unknown = text
+  try {
+    payload = text ? JSON.parse(text) : {}
+  } catch {}
+
+  printOutput(options, {
+    endpoint,
+    request: {
+      method: request.method,
+      url: request.url,
+      body: request.body
+    },
+    response: {
+      status: response.status,
+      statusText: response.statusText,
+      body: payload
+    }
+  })
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
+    .option('--owner <owner>', 'Sentio project owner')
+    .option('--name <name>', 'Sentio project name')
+    .option('--project-id <id>', 'Sentio project id')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
+}
+
+function handleEndpointCommandError(error: unknown, command?: Command) {
+  if (
+    error instanceof CliError &&
+    (error.message.startsWith('Project is required.') ||
+      error.message.startsWith('Invalid project ') ||
+      error.message.startsWith('SQL query is required.') ||
+      error.message.startsWith('Invalid --args JSON') ||
+      error.message.startsWith('Unsupported argument type ') ||
+      error.message.startsWith('Failed to create endpoint SQL query.') ||
+      error.message.startsWith('Failed to delete endpoint '))
+  ) {
+    console.error(error.message)
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function printOutput(options: EndpointOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+  if (options.yaml) {
+    console.log(yaml.stringify(data).trimEnd())
+    return
+  }
+  console.log(formatOutput(data))
+}
+
+function formatOutput(data: unknown) {
+  if (data && typeof data === 'object' && Array.isArray((data as { endpoints?: unknown[] }).endpoints)) {
+    const endpoints = (data as { endpoints: EndpointRecord[] }).endpoints
+    const lines = [`Endpoints (${endpoints.length})`]
+    for (const endpoint of endpoints) {
+      lines.push(`- ${endpoint.name ?? endpoint.slug ?? '<endpoint>'}`)
+      lines.push(
+        `  id=${endpoint.id ?? '?'} slug=${endpoint.slug ?? '?'} ${endpoint.isPublic ? 'public' : 'private'} ${endpoint.enabled === false ? 'disabled' : 'enabled'}`
+      )
+    }
+    return lines.join('\n')
+  }
+
+  if (
+    data &&
+    typeof data === 'object' &&
+    'endpoint' in (data as Record<string, unknown>) &&
+    'docs' in (data as Record<string, unknown>)
+  ) {
+    const objectData = data as { endpoint?: EndpointRecord; docs?: EndpointDocResponse; sqlQuery?: SqlGetResponse }
+    const endpoint = objectData.endpoint ?? {}
+    const docs = objectData.docs ?? {}
+    const lines = [`Endpoint: ${endpoint.name ?? endpoint.slug ?? '<endpoint>'}`]
+    lines.push(`ID: ${endpoint.id ?? '?'}`)
+    if (endpoint.slug) {
+      lines.push(`Slug: ${endpoint.slug}`)
+    }
+    lines.push(`Visibility: ${endpoint.isPublic ? 'public' : 'private'}`)
+    lines.push(`Enabled: ${endpoint.enabled === false ? 'false' : 'true'}`)
+    if (docs.endpointUrl) {
+      lines.push(`URL: ${docs.endpointUrl}`)
+    }
+    if (endpoint.sqlQueryId) {
+      lines.push(`SQL Query ID: ${endpoint.sqlQueryId}`)
+    }
+    const sql = objectData.sqlQuery?.sqlQuery?.sql
+    if (sql) {
+      lines.push('')
+      lines.push('SQL')
+      lines.push(sql)
+    }
+    lines.push('')
+    lines.push('Arguments')
+    lines.push(...formatEndpointParameters('Path', docs.pathParameters))
+    lines.push(...formatEndpointParameters('Query', docs.queryParameters))
+    lines.push(...formatEndpointParameters('Body', docs.bodyParameters))
+    lines.push('')
+    lines.push('curl')
+    lines.push(buildCurlCommand(docs))
+    return lines.join('\n')
+  }
+
+  if (
+    data &&
+    typeof data === 'object' &&
+    'message' in (data as Record<string, unknown>) &&
+    'endpoint' in (data as Record<string, unknown>)
+  ) {
+    const objectData = data as { message?: string; endpoint?: EndpointRecord }
+    const endpoint = objectData.endpoint ?? {}
+    const lines = [objectData.message ?? 'Endpoint updated']
+    lines.push(`- ${endpoint.name ?? endpoint.slug ?? '<endpoint>'}`)
+    lines.push(`  id=${endpoint.id ?? '?'} slug=${endpoint.slug ?? '?'}`)
+    return lines.join('\n')
+  }
+
+  if (
+    data &&
+    typeof data === 'object' &&
+    'request' in (data as Record<string, unknown>) &&
+    'response' in (data as Record<string, unknown>)
+  ) {
+    const objectData = data as {
+      endpoint?: EndpointRecord
+      request?: { method?: string; url?: string; body?: unknown }
+      response?: { status?: number; statusText?: string; body?: unknown }
+    }
+    const lines = [`Endpoint test: ${objectData.endpoint?.name ?? objectData.endpoint?.slug ?? '<endpoint>'}`]
+    lines.push(`Request: ${objectData.request?.method ?? 'POST'} ${objectData.request?.url ?? ''}`)
+    if (objectData.request?.body && Object.keys(objectData.request.body as Record<string, unknown>).length > 0) {
+      lines.push(`Body: ${JSON.stringify(objectData.request.body)}`)
+    }
+    lines.push(`Response: ${objectData.response?.status ?? '?'} ${objectData.response?.statusText ?? ''}`.trim())
+    if (objectData.response?.body !== undefined) {
+      lines.push(
+        typeof objectData.response.body === 'string'
+          ? objectData.response.body
+          : JSON.stringify(objectData.response.body, null, 2)
+      )
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'message' in (data as Record<string, unknown>)) {
+    return String((data as { message?: string }).message ?? '')
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
+function formatEndpointParameters(label: string, params?: EndpointParameter[]) {
+  const entries = Array.isArray(params) ? params : []
+  if (entries.length === 0) {
+    return [`${label}: none`]
+  }
+  return [
+    `${label}:`,
+    ...entries.map(
+      (param) =>
+        `- ${param.name ?? '?'}${param.type ? ` (${String(param.type).toLowerCase()})` : ''}${param.required ? ' required' : ''}${param.description ? ` - ${param.description}` : ''}`
+    )
+  ]
+}
+
+export function buildCurlCommand(docs: EndpointDocResponse) {
+  const rawUrl = docs.endpointUrl ?? '<endpoint-url>'
+  const pathUrl = rawUrl
+    .split('/')
+    .map((part) => (part.startsWith(':') ? `<${part.slice(1)}>` : part))
+    .join('/')
+  const query = (docs.queryParameters ?? [])
+    .filter((param) => shouldIncludeCurlParameter(param))
+    .map((param) => `${encodeURIComponent(param.name ?? 'param')}=${encodeURIComponent(`<${param.name ?? 'value'}>`)}`)
+    .join('&')
+  const url = query ? `${pathUrl}?${query}` : pathUrl
+  const body = Object.fromEntries(
+    (docs.bodyParameters ?? []).map((param) => [param.name ?? 'param', `<${param.name ?? 'value'}>`])
+  )
+  const method = normalizeEndpointMethod(docs.method)
+  const parts = [`curl '${url}'`, `-X ${method}`, `-H 'Api-Key: <API_KEY>'`, `-H 'Content-Type: application/json'`]
+  if (Object.keys(body).length > 0 && method !== 'GET') {
+    parts.push(`-d '${JSON.stringify(body)}'`)
+  }
+  return parts.join(' \\\n  ')
+}
+
+export function parseEndpointArgSchema(raw?: string) {
+  if (!raw) {
+    return {}
+  }
+  const parsed = parseJsonObject(raw)
+  return Object.fromEntries(Object.entries(parsed).map(([key, type]) => [key, toRichValueTemplate(String(type))]))
+}
+
+export function parseEndpointArgValues(raw?: string) {
+  if (!raw) {
+    return {}
+  }
+  return parseJsonObject(raw)
+}
+
+function parseJsonObject(raw: string) {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('Expected an object')
+    }
+    return parsed
+  } catch (error) {
+    throw new CliError(`Invalid --args JSON: ${String(error)}`)
+  }
+}
+
+export function toRichValueTemplate(type: string) {
+  switch (type.toLowerCase()) {
+    case 'string':
+    case 'text':
+      return { stringValue: '' }
+    case 'int':
+    case 'integer':
+    case 'number':
+    case 'float':
+      return { floatValue: 0 }
+    case 'datetime':
+    case 'time':
+    case 'timestamp':
+      return { timestampValue: '' }
+    case 'bool':
+    case 'boolean':
+      return { boolValue: false }
+    default:
+      throw new CliError(`Unsupported argument type "${type}". Use string, int, number, datetime, or bool.`)
+  }
+}
+
+export function buildEndpointInvocation(docs: EndpointDocResponse, args: Record<string, unknown>) {
+  let url = docs.endpointUrl ?? ''
+  for (const param of docs.pathParameters ?? []) {
+    const name = param.name ?? ''
+    if (name && args[name] !== undefined) {
+      url = url.replace(`:${name}`, encodeURIComponent(String(args[name])))
+    }
+  }
+
+  const queryEntries = (docs.queryParameters ?? [])
+    .filter((param) => param.name && args[param.name] !== undefined)
+    .map((param) => [param.name!, String(args[param.name!])] as [string, string])
+
+  if (queryEntries.length > 0) {
+    const query = new URLSearchParams(queryEntries)
+    url += (url.includes('?') ? '&' : '?') + query.toString()
+  }
+
+  const body = Object.fromEntries(
+    (docs.bodyParameters ?? [])
+      .filter((param) => param.name && args[param.name] !== undefined)
+      .map((param) => [param.name!, args[param.name!]])
+  )
+
+  return {
+    method: normalizeEndpointMethod(docs.method),
+    url,
+    body
+  }
+}
+
+function normalizeEndpointMethod(method?: string) {
+  const normalized = method?.trim().toUpperCase()
+  return normalized || 'POST'
+}
+
+function shouldIncludeCurlParameter(param: EndpointParameter) {
+  return param.required === true
+}
+
+function parseInteger(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}

--- a/packages/cli/src/commands/login-server.ts
+++ b/packages/cli/src/commands/login-server.ts
@@ -3,7 +3,7 @@ import { getAuthConfig, getFinalizedHost } from '../config.js'
 import url from 'url'
 import fetch from 'node-fetch'
 import { getApiUrl, getCliVersion } from '../utils.js'
-import { WriteKey } from '../key.js'
+import { WriteKey, WriteAccessToken } from '../key.js'
 import chalk from 'chalk'
 import http from 'http'
 import os from 'os'
@@ -13,6 +13,10 @@ interface AuthParams {
   serverPort: number
   sentioHost: string
   codeVerifier: string
+  /** Called on successful login instead of process.exit() when provided. */
+  onSuccess?: () => void
+  /** Called on login failure instead of process.exit() when provided. */
+  onFailure?: (err: Error) => void
 }
 
 const app = express()
@@ -26,11 +30,16 @@ export function startServer(params: AuthParams) {
 }
 
 app.get('/callback', async (req, res) => {
-  const fail = function (...args: any[]) {
-    console.error(chalk.red(args))
-    res.end(args.toString())
+  const fail = function (message: string) {
+    console.error(chalk.red(message))
+    res.end(message)
     server.close()
-    setTimeout(() => process.exit(), 1000)
+    server.closeAllConnections()
+    if (authParams.onFailure) {
+      authParams.onFailure(new Error(message))
+    } else {
+      setTimeout(() => process.exit(), 1000)
+    }
   }
 
   const host = getFinalizedHost(authParams.sentioHost)
@@ -75,11 +84,22 @@ app.get('/callback', async (req, res) => {
   const { key, username } = (await createApiKeyResRaw.json()) as { key: string; username: string }
   WriteKey(host, key)
 
+  // store access token with expiry for commands that require admin permissions
+  const expiresAt = decodeJwtExpiry(accessToken)
+  if (expiresAt !== undefined) {
+    WriteAccessToken(host, accessToken, expiresAt)
+  }
+
   res.end('Login success, please go back to CLI to continue')
   console.log(chalk.green(`Login success with ${username}, new API key: ${key}`))
 
   server.close()
-  setTimeout(() => process.exit(), 1000)
+  server.closeAllConnections()
+  if (authParams.onSuccess) {
+    authParams.onSuccess()
+  } else {
+    setTimeout(() => process.exit(), 1000)
+  }
 })
 
 async function getToken(host: string, code: string) {
@@ -125,4 +145,14 @@ async function getUser(host: string, accessToken: string) {
       version: getCliVersion()
     }
   })
+}
+
+function decodeJwtExpiry(token: string): number | undefined {
+  try {
+    const b64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')
+    const payload = JSON.parse(Buffer.from(b64, 'base64').toString()) as { exp?: unknown }
+    return typeof payload.exp === 'number' ? payload.exp : undefined
+  } catch {
+    return undefined
+  }
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -46,17 +46,7 @@ function login(options: CommandOptionsType<typeof createLoginCommand>) {
       console.error(chalk.red('invalid host, try login with an API key if it is a dev env'))
       return
     }
-    const authURL = new URL(conf.domain + `/authorize?`)
-    const params = new url.URLSearchParams({
-      response_type: 'code',
-      code_challenge: challenge,
-      code_challenge_method: 'S256',
-      client_id: conf.clientId,
-      redirect_uri: conf.redirectUri,
-      audience: conf.audience,
-      prompt: 'login'
-    })
-    authURL.search = params.toString()
+    const authURL = buildAuthURL(conf, challenge)
 
     console.log('Continue your authorization in the browser')
     open(authURL.toString()).catch((reason) => {
@@ -70,6 +60,57 @@ function login(options: CommandOptionsType<typeof createLoginCommand>) {
       codeVerifier: verifier
     })
   }
+}
+
+/**
+ * Launches the interactive browser-based OAuth login flow and waits for it to complete.
+ * Stores the API key and access token in the local config upon success.
+ * Throws if login fails or the host has no auth config (e.g. local dev environments).
+ */
+export function loginInteractiveAndWait(host: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const conf = getAuthConfig(host)
+    if (conf.domain === '') {
+      reject(new Error('No auth config for this host. Use --api-key for local/dev environments.'))
+      return
+    }
+
+    const verifier = base64URLEncode(crypto.randomBytes(32))
+    const challenge = base64URLEncode(sha256(verifier))
+    const authURL = buildAuthURL(conf, challenge)
+
+    console.log(chalk.blue('Opening browser for login...'))
+    open(authURL.toString()).catch((reason) => {
+      console.error(chalk.yellow('Unable to open browser automatically.'))
+      console.error(chalk.yellow('Open this URL in your browser: ' + authURL.toString()))
+    })
+
+    startServer({
+      serverPort: port,
+      sentioHost: host,
+      codeVerifier: verifier,
+      onSuccess: resolve,
+      onFailure: reject
+    })
+  })
+}
+
+function buildAuthURL(
+  conf: { domain: string; clientId: string; audience: string; redirectUri: string },
+  challenge: string
+): URL {
+  const authURL = new URL(conf.domain + `/authorize?`)
+  const params = new url.URLSearchParams({
+    response_type: 'code',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    client_id: conf.clientId,
+    redirect_uri: conf.redirectUri,
+    audience: conf.audience,
+    prompt: 'login'
+  })
+  authURL.search = params.toString()
+  return authURL
 }
 
 function base64URLEncode(str: Buffer) {

--- a/packages/cli/src/commands/price.ts
+++ b/packages/cli/src/commands/price.ts
@@ -1,0 +1,373 @@
+import { PriceService } from '@sentio/api'
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings'
+import process from 'process'
+import yaml from 'yaml'
+import { CliError, createApiContext, handleCommandError, loadJsonInput, unwrapApiResult } from '../api.js'
+
+interface PriceOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  json?: boolean
+  yaml?: boolean
+}
+
+interface PriceGetOptions extends PriceOptions {
+  coin?: string
+  symbol?: string
+  address?: string
+  chain?: string
+  timestamp?: string
+  source?: string
+  enablePythSource?: boolean
+}
+
+interface PriceBatchOptions extends PriceOptions {
+  file?: string
+  stdin?: boolean
+}
+
+interface PriceCoinsOptions extends PriceOptions {
+  limit?: number
+  offset?: number
+  searchQuery?: string
+  chain?: string
+}
+
+interface PriceCoinId {
+  symbol?: string
+  address?: {
+    address?: string
+    chain?: string
+  }
+}
+
+export function createPriceCommand() {
+  const priceCommand = new Command('price').description('Query Sentio price data')
+  priceCommand.addCommand(createPriceGetCommand())
+  priceCommand.addCommand(createPriceBatchCommand())
+  priceCommand.addCommand(createPriceCoinsCommand())
+  priceCommand.addCommand(createPriceCheckLatestCommand())
+  return priceCommand
+}
+
+function createPriceGetCommand() {
+  return withOutputOptions(withAuthOptions(new Command('get').description('Get a coin price')))
+    .showHelpAfterError()
+    .option('--coin <id>', 'Coin id as SYMBOL or chain:0xaddress')
+    .option('--symbol <symbol>', 'Coin symbol like ETH')
+    .option('--address <address>', 'Coin contract address')
+    .option('--chain <chain>', 'Chain identifier for --address')
+    .option('--timestamp <timestamp>', 'Requested timestamp')
+    .option('--source <source>', 'Optional price source override')
+    .option('--enable-pyth-source', 'Enable Pyth source in experimental flag')
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio price get --symbol ETH
+  $ sentio price get --coin ETH
+  $ sentio price get --coin 1:0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2
+  $ sentio price get --address 0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2 --chain 1
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runPriceGet(options)
+      } catch (error) {
+        handlePriceCommandError(error, command)
+      }
+    })
+}
+
+function createPriceBatchCommand() {
+  return withOutputOptions(withJsonInputOptions(withAuthOptions(new Command('batch').description('Batch get prices'))))
+    .showHelpAfterError()
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio price batch --file prices.yaml
+  $ sentio price batch --stdin < prices.json
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runPriceBatch(options)
+      } catch (error) {
+        handlePriceCommandError(error, command)
+      }
+    })
+}
+
+function createPriceCoinsCommand() {
+  return withOutputOptions(withAuthOptions(new Command('coins').description('List supported coins')))
+    .showHelpAfterError()
+    .option('--limit <count>', 'Limit results', parseInteger)
+    .option('--offset <count>', 'Offset results', parseInteger)
+    .option('--search-query <query>', 'Search query')
+    .option('--chain <chain>', 'Filter by chain')
+    .action(async (options, command) => {
+      try {
+        await runPriceCoins(options)
+      } catch (error) {
+        handlePriceCommandError(error, command)
+      }
+    })
+}
+
+function createPriceCheckLatestCommand() {
+  return withOutputOptions(withAuthOptions(new Command('check-latest').description('Check latest available prices')))
+    .showHelpAfterError()
+    .action(async (options, command) => {
+      try {
+        await runPriceCheckLatest(options)
+      } catch (error) {
+        handlePriceCommandError(error, command)
+      }
+    })
+}
+
+async function runPriceGet(options: PriceGetOptions) {
+  const context = createApiContext(options)
+  const coin = normalizeCoinInput(options)
+  const response = await PriceService.getPrice({
+    query: {
+      timestamp: options.timestamp,
+      'coinId.symbol': coin.symbol,
+      'coinId.address.address': coin.address?.address,
+      'coinId.address.chain': coin.address?.chain,
+      source: options.source,
+      'experimentalFlag.enablePythSource': options.enablePythSource
+    },
+    headers: context.headers
+  })
+  printOutput(options, {
+    coinId: coin,
+    ...(unwrapApiResult(response) as Record<string, unknown>)
+  })
+}
+
+async function runPriceBatch(options: PriceBatchOptions) {
+  const context = createApiContext(options)
+  const body = loadJsonInput(options)
+  if (!body) {
+    throw new CliError('Provide --file or --stdin for price batch.')
+  }
+  const response = await PriceService.batchGetPrices({
+    body: body as never,
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runPriceCoins(options: PriceCoinsOptions) {
+  const context = createApiContext(options)
+  const response = await PriceService.priceListCoins({
+    query: {
+      limit: options.limit,
+      offset: options.offset,
+      searchQuery: options.searchQuery,
+      chain: options.chain
+    },
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runPriceCheckLatest(options: PriceOptions) {
+  const context = createApiContext(options)
+  const response = await PriceService.checkLatestPrice({
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--file <path>', 'Read request JSON or YAML from file')
+    .option('--stdin', 'Read request JSON or YAML from stdin')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
+}
+
+function handlePriceCommandError(error: unknown, command?: Command) {
+  if (
+    error instanceof CliError &&
+    (error.message.startsWith('Provide exactly one coin identifier.') ||
+      error.message.startsWith('Address-based price lookup requires --chain.') ||
+      error.message.startsWith('Provide --file or --stdin for price batch.'))
+  ) {
+    console.error(error.message)
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function printOutput(options: PriceOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+  if (options.yaml) {
+    console.log(yaml.stringify(data).trimEnd())
+    return
+  }
+  console.log(formatOutput(data))
+}
+
+function formatOutput(data: unknown) {
+  if (
+    data &&
+    typeof data === 'object' &&
+    ('price' in (data as Record<string, unknown>) || 'coinId' in (data as Record<string, unknown>))
+  ) {
+    const objectData = data as Record<string, unknown>
+    const lines = [`Coin: ${formatCoinId(objectData.coinId)}`]
+    if (typeof objectData.price === 'number') {
+      lines.push(`Price: ${objectData.price} USD`)
+    }
+    if (typeof objectData.timestamp === 'string') {
+      lines.push(`Timestamp: ${objectData.timestamp}`)
+    }
+    if (typeof objectData.source === 'string') {
+      lines.push(`Source: ${objectData.source}`)
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && Array.isArray((data as { prices?: unknown[] }).prices)) {
+    const prices = (data as { prices: Array<Record<string, unknown>> }).prices
+    const lines = [`Prices (${prices.length})`]
+    for (const entry of prices) {
+      const coin = formatCoinId(entry.coinId)
+      const priceObject = entry.price as Record<string, unknown> | undefined
+      const result = Array.isArray(priceObject?.results)
+        ? (priceObject?.results?.[0] as Record<string, unknown> | undefined)
+        : undefined
+      const error = typeof entry.error === 'string' ? entry.error : undefined
+      if (error) {
+        lines.push(`- ${coin}: error=${error}`)
+        continue
+      }
+      lines.push(
+        `- ${coin}: ${typeof result?.price === 'number' ? `${result.price} USD` : 'n/a'}${typeof result?.timestamp === 'string' ? ` at ${result.timestamp}` : ''}`
+      )
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && Array.isArray((data as { coins?: unknown[] }).coins)) {
+    const coins = (data as { coins: Array<Record<string, unknown>> }).coins
+    const lines = [`Coins (${coins.length})`]
+    for (const coin of coins) {
+      lines.push(`- ${formatCoinId(coin)}`)
+    }
+    return lines.join('\n')
+  }
+
+  if (
+    data &&
+    typeof data === 'object' &&
+    ('latestPrice' in (data as Record<string, unknown>) || 'prices' in (data as Record<string, unknown>))
+  ) {
+    const objectData = data as { latestPrice?: Record<string, unknown>; prices?: Array<Record<string, unknown>> }
+    const lines: string[] = []
+    if (objectData.latestPrice) {
+      lines.push('Latest price')
+      lines.push(
+        `- ${formatCoinId(objectData.latestPrice.coinId)}: ${objectData.latestPrice.price ?? 'n/a'} USD${objectData.latestPrice.timestamp ? ` at ${objectData.latestPrice.timestamp}` : ''}`
+      )
+    }
+    const prices = Array.isArray(objectData.prices) ? objectData.prices : []
+    if (prices.length > 0) {
+      lines.push(`Prices (${prices.length})`)
+      for (const entry of prices) {
+        lines.push(
+          `- ${formatCoinId(entry.coinId)}: ${entry.price ?? 'n/a'} USD${entry.timestamp ? ` at ${entry.timestamp}` : ''}`
+        )
+      }
+    }
+    return lines.join('\n')
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
+function normalizeCoinInput(options: PriceGetOptions): PriceCoinId {
+  const explicitKinds = [Boolean(options.coin), Boolean(options.symbol), Boolean(options.address)].filter(
+    Boolean
+  ).length
+  if (explicitKinds !== 1) {
+    throw new CliError('Provide exactly one coin identifier. Use --coin, --symbol, or --address.')
+  }
+
+  if (options.coin) {
+    return parseCoinIdentifier(options.coin)
+  }
+  if (options.symbol) {
+    return { symbol: options.symbol }
+  }
+  if (!options.chain) {
+    throw new CliError('Address-based price lookup requires --chain.')
+  }
+  return {
+    address: {
+      address: options.address,
+      chain: options.chain
+    }
+  }
+}
+
+function parseCoinIdentifier(value: string) {
+  const trimmed = value.trim()
+  const addressMatch = /^([^:]+):(0x[a-fA-F0-9]+)$/.exec(trimmed)
+  if (addressMatch) {
+    return {
+      address: {
+        chain: addressMatch[1],
+        address: addressMatch[2]
+      }
+    }
+  }
+  return {
+    symbol: trimmed
+  }
+}
+
+function formatCoinId(value: unknown) {
+  const coin = (value ?? {}) as { symbol?: string; address?: { address?: string; chain?: string } }
+  if (coin.symbol) {
+    return coin.symbol
+  }
+  if (coin.address?.chain || coin.address?.address) {
+    return `${coin.address?.chain ?? '?'}:${coin.address?.address ?? '?'}`
+  }
+  return '<coin>'
+}
+
+function parseInteger(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}

--- a/packages/cli/src/commands/processor.ts
+++ b/packages/cli/src/commands/processor.ts
@@ -1,0 +1,327 @@
+import { ProcessorExtService, ProcessorService } from '@sentio/api'
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings'
+import process from 'process'
+import yaml from 'yaml'
+import { CliError, createApiContext, handleCommandError, resolveProjectRef, unwrapApiResult } from '../api.js'
+
+interface ProcessorOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+  json?: boolean
+  yaml?: boolean
+}
+
+interface ProcessorStatusOptions extends ProcessorOptions {
+  version?: string
+}
+
+interface ProcessorSourceOptions extends ProcessorOptions {
+  version?: number
+  path?: string
+}
+
+export function createProcessorCommand() {
+  const processorCommand = new Command('processor').description('Manage Sentio processor versions')
+  processorCommand.addCommand(createProcessorStatusCommand())
+  processorCommand.addCommand(createProcessorSourceCommand())
+  processorCommand.addCommand(createProcessorActivatePendingCommand())
+  return processorCommand
+}
+
+function createProcessorStatusCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('status').description('Get processor status')))
+  )
+    .showHelpAfterError()
+    .option('--version <selector>', 'Version selector: active, pending, or all')
+    .action(async (options, command) => {
+      try {
+        await runProcessorStatus(options)
+      } catch (error) {
+        handleProcessorCommandError(error, command)
+      }
+    })
+}
+
+function createProcessorSourceCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('source').description('Get processor source files')))
+  )
+    .showHelpAfterError()
+    .option('--version <version>', 'Processor version', parseInteger)
+    .option('--path <path>', 'Show only one source file by path')
+    .action(async (options, command) => {
+      try {
+        await runProcessorSource(options)
+      } catch (error) {
+        handleProcessorCommandError(error, command)
+      }
+    })
+}
+
+function createProcessorActivatePendingCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(
+      withAuthOptions(new Command('activate-pending').description('Activate the pending version'))
+    )
+  )
+    .showHelpAfterError()
+    .action(async (options, command) => {
+      try {
+        await runActivatePending(options)
+      } catch (error) {
+        handleProcessorCommandError(error, command)
+      }
+    })
+}
+
+async function runProcessorStatus(options: ProcessorStatusOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const requestedVersion = normalizeVersionSelector(options.version)
+  const response = await ProcessorService.getProcessorStatusV2({
+    path: {
+      owner: project.owner,
+      slug: project.slug
+    },
+    query: {
+      version: requestedVersion ?? 'ALL'
+    },
+    headers: context.headers
+  })
+  const data = unwrapApiResult(response)
+  if (!options.json) {
+    printOutput(options, shapeProcessorStatusOutput(data, requestedVersion))
+    return
+  }
+  printOutput(options, data)
+}
+
+async function runProcessorSource(options: ProcessorSourceOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await ProcessorExtService.getProcessorSourceFiles({
+    path: {
+      owner: project.owner,
+      slug: project.slug
+    },
+    query: {
+      version: options.version
+    },
+    headers: context.headers
+  })
+  const data = unwrapApiResult(response)
+  if (options.path && Array.isArray(data.sourceFiles)) {
+    const sourceFile = data.sourceFiles.find((entry) => entry.path === options.path)
+    if (!sourceFile) {
+      throw new CliError(`Source file not found: ${options.path}`)
+    }
+    printOutput(options, sourceFile)
+    return
+  }
+  printOutput(options, data)
+}
+
+async function runActivatePending(options: ProcessorOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await ProcessorService.activatePendingVersion({
+    path: {
+      owner: project.owner,
+      slug: project.slug
+    },
+    headers: context.headers
+  })
+  printOutput(options, {
+    project: `${project.owner}/${project.slug}`,
+    ...(unwrapApiResult(response) as Record<string, unknown>)
+  })
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--project <owner/slug>', 'Sentio project in <owner>/<slug> format')
+    .option('--owner <owner>', 'Sentio project owner')
+    .option('--name <name>', 'Sentio project name')
+    .option('--project-id <id>', 'Sentio project id')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
+}
+
+function handleProcessorCommandError(error: unknown, command?: Command) {
+  if (
+    error instanceof CliError &&
+    (error.message.startsWith('Project is required.') ||
+      error.message.startsWith('Invalid project ') ||
+      error.message.startsWith('Invalid version selector ') ||
+      error.message.startsWith('Source file not found:'))
+  ) {
+    console.error(error.message)
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function printOutput(options: ProcessorOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+  if (options.yaml) {
+    console.log(yaml.stringify(data).trimEnd())
+    return
+  }
+  console.log(formatOutput(data))
+}
+
+function formatOutput(data: unknown) {
+  if (data && typeof data === 'object' && Array.isArray((data as { processors?: unknown[] }).processors)) {
+    const processors = (data as { processors: Array<Record<string, unknown>> }).processors
+    const lines = [`Processor versions (${processors.length})`]
+    const groupedProcessors = groupProcessorsByVersionState(processors)
+    for (const group of groupedProcessors) {
+      lines.push(`${group.versionState} (${group.processors.length})`)
+      for (const processor of group.processors) {
+        const version = asNumber(processor.version)
+        const statusState =
+          asString((processor.processorStatus as Record<string, unknown> | undefined)?.state) ?? 'UNKNOWN'
+        const uploadedAt = asString(processor.uploadedAt)
+        lines.push(`- v${version ?? '?'} status=${statusState}${uploadedAt ? ` uploaded=${uploadedAt}` : ''}`)
+        if (asString(processor.processorId)) {
+          lines.push(`  processorId: ${asString(processor.processorId)}`)
+        }
+        const states = Array.isArray(processor.states) ? processor.states : []
+        for (const stateEntry of states.slice(0, 5)) {
+          const state = stateEntry as Record<string, unknown>
+          const chainId = asString(state.chainId) ?? '?'
+          const chainState = asString((state.status as Record<string, unknown> | undefined)?.state) ?? 'UNKNOWN'
+          const block = asString(state.processedBlockNumber) ?? '?'
+          lines.push(`  chain ${chainId}: ${chainState} block=${block}`)
+        }
+        if (states.length > 5) {
+          lines.push(`  ... ${states.length - 5} more chains`)
+        }
+      }
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && Array.isArray((data as { sourceFiles?: unknown[] }).sourceFiles)) {
+    const sourceFiles = (data as { sourceFiles: Array<Record<string, unknown>> }).sourceFiles
+    const lines = [`Source files (${sourceFiles.length})`]
+    for (const file of sourceFiles) {
+      lines.push(`- ${asString(file.path) ?? '<unknown>'}`)
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'path' in (data as Record<string, unknown>)) {
+    const file = data as Record<string, unknown>
+    return [`File: ${asString(file.path) ?? '<unknown>'}`, '', asString(file.content) ?? ''].join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'project' in (data as Record<string, unknown>)) {
+    const objectData = data as Record<string, unknown>
+    return `Pending processor version activated for ${asString(objectData.project) ?? '<project>'}.`
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
+function normalizeVersionSelector(value?: string): 'ACTIVE' | 'PENDING' | 'ALL' | undefined {
+  if (!value) {
+    return undefined
+  }
+  const normalized = value.toUpperCase()
+  if (normalized === 'ACTIVE' || normalized === 'PENDING' || normalized === 'ALL') {
+    return normalized
+  }
+  throw new CliError(`Invalid version selector "${value}". Use active, pending, or all.`)
+}
+
+function parseInteger(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asNumber(value: unknown) {
+  return typeof value === 'number' ? value : undefined
+}
+
+function shapeProcessorStatusOutput(
+  data: { processors?: Array<Record<string, unknown>> },
+  versionSelector?: 'ACTIVE' | 'PENDING' | 'ALL'
+) {
+  const processors = Array.isArray(data.processors) ? data.processors : []
+  if (versionSelector === 'ALL') {
+    return { ...data, processors }
+  }
+  if (versionSelector === 'ACTIVE' || versionSelector === 'PENDING') {
+    return {
+      ...data,
+      processors: processors.filter((processor) => asString(processor.versionState) === versionSelector)
+    }
+  }
+  return {
+    ...data,
+    processors: processors.filter((processor) => {
+      const versionState = asString(processor.versionState)
+      return versionState === 'ACTIVE' || versionState === 'PENDING'
+    })
+  }
+}
+
+function groupProcessorsByVersionState(processors: Array<Record<string, unknown>>) {
+  const grouped = new Map<string, Array<Record<string, unknown>>>()
+  for (const processor of processors) {
+    const versionState = asString(processor.versionState) ?? 'UNKNOWN'
+    const existing = grouped.get(versionState)
+    if (existing) {
+      existing.push(processor)
+      continue
+    }
+    grouped.set(versionState, [processor])
+  }
+
+  const order = ['ACTIVE', 'PENDING', 'OBSOLETE', 'UNKNOWN']
+  return Array.from(grouped.entries())
+    .sort((left, right) => {
+      const leftIndex = order.indexOf(left[0])
+      const rightIndex = order.indexOf(right[0])
+      return (leftIndex === -1 ? order.length : leftIndex) - (rightIndex === -1 ? order.length : rightIndex)
+    })
+    .map(([versionState, groupedProcessors]) => ({
+      versionState,
+      processors: [...groupedProcessors].sort(
+        (left, right) => (asNumber(right.version) ?? 0) - (asNumber(left.version) ?? 0)
+      )
+    }))
+}

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,0 +1,391 @@
+import { Command } from '@commander-js/extra-typings'
+import process from 'process'
+import yaml from 'yaml'
+import {
+  CliError,
+  createApiContext,
+  fetchApiJson,
+  handleCommandError,
+  postApiJson,
+  resolveProjectSlugInput
+} from '../api.js'
+
+interface ProjectAuthOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  json?: boolean
+  yaml?: boolean
+}
+
+interface ProjectListOptions extends ProjectAuthOptions {
+  owner?: string
+}
+
+interface ProjectListOutput {
+  projects: ProjectSummary[]
+  grouped: boolean
+}
+
+interface ProjectLookupOptions extends ProjectAuthOptions {
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+}
+
+interface ProjectCreateOptions extends ProjectLookupOptions {
+  type?: string
+  visibility?: string
+  sentioNetwork?: boolean
+}
+
+interface ProjectSummary {
+  id?: string
+  slug?: string
+  owner?: string | { organization?: { name?: string }; user?: { username?: string } }
+  ownerName?: string
+  displayName?: string
+  description?: string
+  updatedAt?: string
+  createdAt?: string
+  visibility?: string
+  type?: string
+  sentioNetwork?: boolean
+}
+
+export function createProjectCommand() {
+  const projectCommand = new Command('project').description('Manage Sentio projects')
+  projectCommand.addCommand(createProjectListCommand())
+  projectCommand.addCommand(createProjectGetCommand())
+  projectCommand.addCommand(createProjectCreateCommand())
+  return projectCommand
+}
+
+function createProjectListCommand() {
+  return withOutputOptions(withAuthOptions(new Command('list').description('List projects')))
+    .showHelpAfterError()
+    .option('--owner <name>', 'Filter projects by owner')
+    .action(async (options, command) => {
+      try {
+        await runProjectList(options)
+      } catch (error) {
+        handleProjectCommandError(error, command)
+      }
+    })
+}
+
+function createProjectGetCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('get').description('Get a project').argument('[project]')))
+  )
+    .showHelpAfterError()
+    .action(async (projectArg, options, command) => {
+      try {
+        if (projectArg) {
+          options.project = projectArg
+        }
+        await runProjectGet(options)
+      } catch (error) {
+        handleProjectCommandError(error, command)
+      }
+    })
+}
+
+function createProjectCreateCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(
+      withAuthOptions(new Command('create').description('Create a project').argument('[project]'))
+    )
+  )
+    .showHelpAfterError()
+    .option('--type <type>', 'Project type: sentio, subgraph, or action')
+    .option('--visibility <visibility>', 'Project visibility: private or public')
+    .option('--sentio-network', 'Create a Sentio Network project')
+    .action(async (projectArg, options, command) => {
+      try {
+        if (projectArg) {
+          options.project = projectArg
+        }
+        await runProjectCreate(options)
+      } catch (error) {
+        handleProjectCommandError(error, command)
+      }
+    })
+}
+
+async function runProjectList(options: ProjectListOptions) {
+  const context = createApiContext(options)
+  const ownerFilter = options.owner
+  if (ownerFilter) {
+    const projects = await getProjectsByOwner(ownerFilter, context)
+    printOutput(options, { projects, grouped: false })
+    return
+  }
+
+  const data = await fetchApiJson<unknown>('/api/v1/projects', context)
+  printOutput(options, { projects: normalizeProjectList(data), grouped: true })
+}
+
+async function runProjectGet(options: ProjectLookupOptions) {
+  const context = createApiContext(options)
+  const data = options.projectId
+    ? await fetchApiJson<{ project?: ProjectSummary }>(`/api/v1/project/${options.projectId}`, context)
+    : await fetchProjectBySlug(options, context)
+  printOutput(options, data)
+}
+
+async function runProjectCreate(options: ProjectCreateOptions) {
+  const context = createApiContext(options)
+  const project = resolveProjectSlugInput(options)
+  const data = await postApiJson<Record<string, unknown>>('/api/v1/projects', context, {
+    slug: project.slug,
+    ownerName: project.owner,
+    type: normalizeProjectType(options.type),
+    visibility: normalizeProjectVisibility(options.visibility),
+    sentioNetwork: options.sentioNetwork ?? false
+  })
+  printOutput(options, {
+    id: asString(data.id),
+    slug: project.slug,
+    ownerName: project.owner,
+    type: normalizeProjectType(options.type),
+    visibility: normalizeProjectVisibility(options.visibility),
+    sentioNetwork: options.sentioNetwork ?? false
+  })
+}
+
+async function fetchProjectBySlug(options: ProjectLookupOptions, context: ReturnType<typeof createApiContext>) {
+  const project = resolveProjectSlugInput(options)
+  return fetchApiJson<{ project?: ProjectSummary }>(`/api/v1/project/${project.owner}/${project.slug}`, context)
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--project <owner/slug>', 'Sentio project in <owner>/<slug> format')
+    .option('--owner <owner>', 'Sentio project owner')
+    .option('--name <name>', 'Sentio project name')
+    .option('--project-id <id>', 'Sentio project id')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
+}
+
+function handleProjectCommandError(error: unknown, command?: Command) {
+  if (
+    error instanceof CliError &&
+    (error.message.startsWith('Project is required.') ||
+      error.message.startsWith('Invalid project ') ||
+      error.message.startsWith('Owner not found:'))
+  ) {
+    console.error(error.message)
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function printOutput(options: ProjectAuthOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+  if (options.yaml) {
+    console.log(yaml.stringify(data).trimEnd())
+    return
+  }
+  console.log(formatOutput(data))
+}
+
+function formatOutput(data: unknown) {
+  if (isProjectListOutput(data)) {
+    const projects = data.projects
+    if (!data.grouped) {
+      const lines = [`Projects (${projects.length})`]
+      for (const project of [...projects].sort((left, right) => (left.slug ?? '').localeCompare(right.slug ?? ''))) {
+        const owner = getOwnerName(project) ?? '<owner>'
+        const slug = project.slug ?? '<slug>'
+        const attrs = [project.type, project.visibility].filter(Boolean).join(', ')
+        const updatedAt = formatTimestamp(project.updatedAt)
+        lines.push(`- ${owner}/${slug}${attrs ? ` [${attrs}]` : ''}${updatedAt ? ` updated ${updatedAt}` : ''}`)
+      }
+      return lines.join('\n')
+    }
+
+    const groupedProjects = groupProjectsByOwner(projects)
+    const lines = [`Projects (${projects.length})`]
+    for (const group of groupedProjects) {
+      lines.push(`${group.owner} (${group.projects.length})`)
+      for (const project of group.projects) {
+        const slug = project.slug ?? '<slug>'
+        const attrs = [project.type, project.visibility].filter(Boolean).join(', ')
+        const updatedAt = formatTimestamp(project.updatedAt)
+        lines.push(`- ${slug}${attrs ? ` [${attrs}]` : ''}${updatedAt ? ` updated ${updatedAt}` : ''}`)
+      }
+    }
+    return lines.join('\n')
+  }
+
+  const project = ((data as { project?: ProjectSummary })?.project ?? data) as ProjectSummary
+  const owner = getOwnerName(project) ?? '<owner>'
+  const slug = project.slug ?? '<slug>'
+  const lines = [`Project: ${owner}/${slug}`]
+  if (project.id) {
+    lines.push(`ID: ${project.id}`)
+  }
+  if (project.type) {
+    lines.push(`Type: ${project.type}`)
+  }
+  if (project.visibility) {
+    lines.push(`Visibility: ${project.visibility}`)
+  }
+  if (project.sentioNetwork !== undefined) {
+    lines.push(`Sentio Network: ${project.sentioNetwork ? 'enabled' : 'disabled'}`)
+  }
+  if (project.displayName) {
+    lines.push(`Display name: ${project.displayName}`)
+  }
+  if (project.description) {
+    lines.push(`Description: ${project.description}`)
+  }
+  if (project.createdAt) {
+    lines.push(`Created: ${formatTimestamp(project.createdAt)}`)
+  }
+  if (project.updatedAt) {
+    lines.push(`Updated: ${formatTimestamp(project.updatedAt)}`)
+  }
+  return lines.join('\n')
+}
+
+function normalizeProjectList(data: unknown): ProjectSummary[] {
+  if (Array.isArray(data)) {
+    return data as ProjectSummary[]
+  }
+  if (data && typeof data === 'object') {
+    const objectData = data as {
+      projects?: ProjectSummary[]
+      sharedProjects?: ProjectSummary[]
+      orgProjects?: ProjectSummary[]
+    }
+    const combined = [
+      ...(objectData.projects ?? []),
+      ...(objectData.sharedProjects ?? []),
+      ...(objectData.orgProjects ?? [])
+    ]
+    const deduped = new Map<string, ProjectSummary>()
+
+    for (const project of combined) {
+      const key = project.id ?? `${getOwnerName(project) ?? ''}/${project.slug ?? ''}`
+      if (!deduped.has(key)) {
+        deduped.set(key, project)
+      }
+    }
+
+    return Array.from(deduped.values())
+  }
+  return []
+}
+
+function groupProjectsByOwner(projects: ProjectSummary[]) {
+  const grouped = new Map<string, ProjectSummary[]>()
+  for (const project of projects) {
+    const owner = getOwnerName(project) ?? '<owner>'
+    const existing = grouped.get(owner)
+    if (existing) {
+      existing.push(project)
+      continue
+    }
+    grouped.set(owner, [project])
+  }
+
+  return Array.from(grouped.entries())
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map(([owner, ownerProjects]) => ({
+      owner,
+      projects: [...ownerProjects].sort((left, right) => (left.slug ?? '').localeCompare(right.slug ?? ''))
+    }))
+}
+
+function normalizeProjectType(value?: string) {
+  if (!value) {
+    return 'SENTIO'
+  }
+  const normalized = value.toUpperCase()
+  if (normalized === 'SENTIO' || normalized === 'SUBGRAPH' || normalized === 'ACTION') {
+    return normalized
+  }
+  throw new CliError(`Invalid project type "${value}". Use sentio, subgraph, or action.`)
+}
+
+function normalizeProjectVisibility(value?: string) {
+  if (!value) {
+    return 'PRIVATE'
+  }
+  const normalized = value.toUpperCase()
+  if (normalized === 'PRIVATE' || normalized === 'PUBLIC') {
+    return normalized
+  }
+  throw new CliError(`Invalid visibility "${value}". Use private or public.`)
+}
+
+function formatTimestamp(value?: string) {
+  if (!value) {
+    return ''
+  }
+  if (/^\d{13}$/.test(value)) {
+    return new Date(Number.parseInt(value, 10)).toISOString()
+  }
+  return value
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}
+
+function getOwnerName(project: ProjectSummary) {
+  if (typeof project.owner === 'string') {
+    return project.owner
+  }
+  return project.ownerName ?? project.owner?.organization?.name ?? project.owner?.user?.username
+}
+
+function isProjectListOutput(data: unknown): data is ProjectListOutput {
+  return !!data && typeof data === 'object' && Array.isArray((data as ProjectListOutput).projects)
+}
+
+async function getProjectsByOwner(ownerName: string, context: ReturnType<typeof createApiContext>) {
+  try {
+    const organizationResponse = await fetchApiJson<{
+      organizations?: Array<{ id?: string; name?: string; projects?: ProjectSummary[] }>
+    }>('/api/v1/organizations', context, { orgIdOrName: ownerName })
+    const organization = organizationResponse.organizations?.find((entry) => entry.name === ownerName)
+    if (organization) {
+      return organization.projects ?? []
+    }
+  } catch {}
+  try {
+    const userInfo = await fetchApiJson<{ id?: string; username?: string }>('/api/v1/users/info', context, {
+      userName: ownerName
+    })
+    if (userInfo.id) {
+      const data = await fetchApiJson<unknown>('/api/v1/projects', context, { userId: userInfo.id })
+      return normalizeProjectList(data)
+    }
+  } catch {}
+
+  throw new CliError(`Owner not found: ${ownerName}`)
+}

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,14 +1,20 @@
 import { Command } from '@commander-js/extra-typings'
 import process from 'process'
+import readline from 'readline'
 import yaml from 'yaml'
+import chalk from 'chalk'
 import {
   CliError,
   createApiContext,
   fetchApiJson,
   handleCommandError,
   postApiJson,
+  resolveProjectRef,
   resolveProjectSlugInput
 } from '../api.js'
+import { getApiUrl, getCliVersion } from '../utils.js'
+import { ReadAccessToken, isAccessTokenExpired } from '../key.js'
+import { loginInteractiveAndWait } from './login.js'
 
 interface ProjectAuthOptions {
   host?: string
@@ -40,6 +46,10 @@ interface ProjectCreateOptions extends ProjectLookupOptions {
   sentioNetwork?: boolean
 }
 
+interface ProjectDeleteOptions extends ProjectLookupOptions {
+  yes?: boolean
+}
+
 interface ProjectSummary {
   id?: string
   slug?: string
@@ -59,6 +69,7 @@ export function createProjectCommand() {
   projectCommand.addCommand(createProjectListCommand())
   projectCommand.addCommand(createProjectGetCommand())
   projectCommand.addCommand(createProjectCreateCommand())
+  projectCommand.addCommand(createProjectDeleteCommand())
   return projectCommand
 }
 
@@ -114,6 +125,26 @@ function createProjectCreateCommand() {
     })
 }
 
+function createProjectDeleteCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(
+      withAuthOptions(new Command('delete').description('Delete a project').argument('[project]'))
+    )
+  )
+    .showHelpAfterError()
+    .option('-y, --yes', 'Skip confirmation prompt (requires a valid login session — will not open browser)')
+    .action(async (projectArg, options, command) => {
+      try {
+        if (projectArg) {
+          options.project = projectArg
+        }
+        await runProjectDelete(options)
+      } catch (error) {
+        handleProjectCommandError(error, command)
+      }
+    })
+}
+
 async function runProjectList(options: ProjectListOptions) {
   const context = createApiContext(options)
   const ownerFilter = options.owner
@@ -155,6 +186,82 @@ async function runProjectCreate(options: ProjectCreateOptions) {
   })
 }
 
+async function runProjectDelete(options: ProjectDeleteOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true, projectId: true })
+
+  // Project deletion requires admin permission — must use access token (Bearer), not api-key.
+  // With -y: error if token missing/expired (no browser). Without -y: open browser if needed.
+  const accessToken = await requireAccessToken(context.host, { strict: options.yes ?? false })
+
+  if (!options.yes) {
+    const confirmed = await confirmDelete(`${project.owner}/${project.slug}`)
+    if (!confirmed) {
+      console.log('Delete cancelled.')
+      return
+    }
+  }
+
+  const url = getApiUrl(`/api/v1/projects/${project.projectId}`, context.host)
+  const response = await fetch(url.href, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      version: getCliVersion()
+    }
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new CliError(
+      `Failed to delete project ${project.owner}/${project.slug}: ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}`
+    )
+  }
+  printOutput(options, { message: `Project deleted: ${project.owner}/${project.slug}` })
+}
+
+async function requireAccessToken(host: string, { strict }: { strict: boolean }): Promise<string> {
+  const stored = ReadAccessToken(host)
+  if (stored && !isAccessTokenExpired(stored.expiresAt)) {
+    return stored.token
+  }
+
+  if (strict) {
+    // -y was passed: do not open browser, just fail fast
+    throw new CliError(
+      'Deleting a project requires admin permission, but your login session is missing or expired.\n' +
+        'Run `sentio login` to refresh your session, then retry.'
+    )
+  }
+
+  // Interactive: launch browser login to obtain a fresh token
+  console.log(
+    chalk.yellow(
+      'Deleting a project requires admin permission, but your login session is missing or expired.\n' +
+        'Opening the browser to log you in...'
+    )
+  )
+  await loginInteractiveAndWait(host)
+
+  const refreshed = ReadAccessToken(host)
+  if (!refreshed) {
+    throw new CliError('Login succeeded but no access token was saved. Please try again.')
+  }
+  return refreshed.token
+}
+
+async function confirmDelete(projectSlug: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => {
+    rl.question(
+      chalk.yellow(`Are you sure you want to delete project "${projectSlug}"? This cannot be undone. [y/N] `),
+      (answer) => {
+        rl.close()
+        resolve(answer.trim().toLowerCase() === 'y')
+      }
+    )
+  })
+}
+
 async function fetchProjectBySlug(options: ProjectLookupOptions, context: ReturnType<typeof createApiContext>) {
   const project = resolveProjectSlugInput(options)
   return fetchApiJson<{ project?: ProjectSummary }>(`/api/v1/project/${project.owner}/${project.slug}`, context)
@@ -184,7 +291,8 @@ function handleProjectCommandError(error: unknown, command?: Command) {
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||
       error.message.startsWith('Invalid project ') ||
-      error.message.startsWith('Owner not found:'))
+      error.message.startsWith('Owner not found:') ||
+      error.message.startsWith('Failed to delete project '))
   ) {
     console.error(error.message)
     if (command) {
@@ -238,6 +346,10 @@ function formatOutput(data: unknown) {
       }
     }
     return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'message' in (data as Record<string, unknown>)) {
+    return String((data as { message?: string }).message ?? '')
   }
 
   const project = ((data as { project?: ProjectSummary })?.project ?? data) as ProjectSummary

--- a/packages/cli/src/commands/simulation.ts
+++ b/packages/cli/src/commands/simulation.ts
@@ -1,0 +1,527 @@
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings'
+import process from 'process'
+import yaml from 'yaml'
+import { DebugAndSimulationService } from '@sentio/api'
+import {
+  CliError,
+  createApiContext,
+  handleCommandError,
+  loadJsonInput,
+  resolveProjectRef,
+  unwrapApiResult
+} from '../api.js'
+
+interface SimulationOptions {
+  host?: string
+  apiKey?: string
+  token?: string
+  project?: string
+  owner?: string
+  name?: string
+  projectId?: string
+  json?: boolean
+  yaml?: boolean
+}
+
+interface SimulationListOptions extends SimulationOptions {
+  labelContains?: string
+  page?: number
+  pageSize?: number
+}
+
+interface SimulationRunOptions extends SimulationOptions {
+  chainId?: string
+  file?: string
+  stdin?: boolean
+}
+
+interface SimulationTraceOptions extends SimulationOptions {
+  chainId?: string
+  withInternalCalls?: boolean
+  disableOptimizer?: boolean
+  ignoreGasCost?: boolean
+}
+
+export function createSimulationCommand() {
+  const simulationCommand = new Command('simulation').description('Manage Sentio Solidity simulations')
+  simulationCommand.addCommand(createSimulationListCommand())
+  simulationCommand.addCommand(createSimulationGetCommand())
+  simulationCommand.addCommand(createSimulationBundleCommand())
+  simulationCommand.addCommand(createSimulationRunCommand())
+  simulationCommand.addCommand(createSimulationRunBundleCommand())
+  simulationCommand.addCommand(createSimulationTraceCommand())
+  return simulationCommand
+}
+
+function createSimulationListCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(withAuthOptions(new Command('list').description('List simulations in a project')))
+  )
+    .showHelpAfterError()
+    .option('--label-contains <text>', 'Filter by label substring')
+    .option('--page <page>', 'Page number', parseInteger)
+    .option('--page-size <count>', 'Page size', parseInteger)
+    .action(async (options, command) => {
+      try {
+        await runSimulationList(options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+function createSimulationGetCommand() {
+  return withOutputOptions(
+    withSharedProjectOptions(
+      withAuthOptions(new Command('get').description('Get a simulation').argument('<simulation-id>'))
+    )
+  )
+    .showHelpAfterError()
+    .action(async (simulationId, options, command) => {
+      try {
+        await runSimulationGet(simulationId, options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+function createSimulationBundleCommand() {
+  const bundleCommand = new Command('bundle').description('Get simulation bundles')
+  bundleCommand.addCommand(
+    withOutputOptions(
+      withSharedProjectOptions(
+        withAuthOptions(new Command('get').description('Get a simulation bundle').argument('<bundle-id>'))
+      )
+    )
+      .showHelpAfterError()
+      .action(async (bundleId, options, command) => {
+        try {
+          await runSimulationBundleGet(bundleId, options)
+        } catch (error) {
+          handleSimulationCommandError(error, command)
+        }
+      })
+  )
+  return bundleCommand
+}
+
+function createSimulationRunCommand() {
+  return withOutputOptions(
+    withJsonInputOptions(
+      withSharedProjectOptions(withAuthOptions(new Command('run').description('Run a transaction simulation')))
+    )
+  )
+    .showHelpAfterError()
+    .option('--chain-id <id>', 'Chain id')
+    .addHelpText(
+      'after',
+      `
+
+Examples:
+  $ sentio simulation run --project sentio/coinbase --chain-id 1 --file simulation.yaml
+`
+    )
+    .action(async (options, command) => {
+      try {
+        await runSimulation(options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+function createSimulationRunBundleCommand() {
+  return withOutputOptions(
+    withJsonInputOptions(
+      withSharedProjectOptions(withAuthOptions(new Command('run-bundle').description('Run a bundle simulation')))
+    )
+  )
+    .showHelpAfterError()
+    .option('--chain-id <id>', 'Chain id')
+    .action(async (options, command) => {
+      try {
+        await runSimulationBundle(options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+function createSimulationTraceCommand() {
+  const traceCommand = new Command('trace').description('Fetch call traces')
+  traceCommand.addCommand(createSimulationTraceBySimulationCommand())
+  traceCommand.addCommand(createSimulationTraceByBundleCommand())
+  traceCommand.addCommand(createSimulationTraceByTxCommand())
+  return traceCommand
+}
+
+function createSimulationTraceBySimulationCommand() {
+  return withOutputOptions(
+    withTraceOptions(
+      withSharedProjectOptions(
+        withAuthOptions(new Command('simulation').description('Get trace by simulation').argument('<simulation-id>'))
+      )
+    )
+  )
+    .showHelpAfterError()
+    .action(async (simulationId, options, command) => {
+      try {
+        await runTraceBySimulation(simulationId, options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+function createSimulationTraceByBundleCommand() {
+  return withOutputOptions(
+    withTraceOptions(
+      withSharedProjectOptions(
+        withAuthOptions(new Command('bundle').description('Get trace by bundle').argument('<bundle-id>'))
+      )
+    )
+  )
+    .showHelpAfterError()
+    .action(async (bundleId, options, command) => {
+      try {
+        await runTraceByBundle(bundleId, options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+function createSimulationTraceByTxCommand() {
+  return withOutputOptions(
+    withTraceOptions(
+      withSharedProjectOptions(
+        withAuthOptions(new Command('tx').description('Get trace by transaction').argument('<tx-hash>'))
+      )
+    )
+  )
+    .showHelpAfterError()
+    .action(async (txHash, options, command) => {
+      try {
+        await runTraceByTransaction(txHash, options)
+      } catch (error) {
+        handleSimulationCommandError(error, command)
+      }
+    })
+}
+
+async function runSimulationList(options: SimulationListOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await DebugAndSimulationService.getSimulations({
+    path: {
+      owner: project.owner,
+      slug: project.slug
+    },
+    query: {
+      labelContains: options.labelContains,
+      page: options.page,
+      pageSize: options.pageSize
+    },
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runSimulationGet(simulationId: string, options: SimulationOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await DebugAndSimulationService.getSimulation({
+    path: {
+      owner: project.owner,
+      slug: project.slug,
+      simulationId
+    },
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runSimulationBundleGet(bundleId: string, options: SimulationOptions) {
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await DebugAndSimulationService.getSimulationBundleInProject({
+    path: {
+      owner: project.owner,
+      slug: project.slug,
+      bundleId
+    },
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runSimulation(options: SimulationRunOptions) {
+  const body = loadJsonInput(options)
+  if (!body) {
+    throw new CliError('Provide --file or --stdin for simulation run.')
+  }
+  if (!options.chainId) {
+    throw new CliError('Chain id is required. Use --chain-id <id>.')
+  }
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await DebugAndSimulationService.simulateTransaction({
+    path: {
+      owner: project.owner,
+      slug: project.slug,
+      chainId: options.chainId
+    },
+    body: body as never,
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runSimulationBundle(options: SimulationRunOptions) {
+  const body = loadJsonInput(options)
+  if (!body) {
+    throw new CliError('Provide --file or --stdin for simulation run-bundle.')
+  }
+  if (!options.chainId) {
+    throw new CliError('Chain id is required. Use --chain-id <id>.')
+  }
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const response = await DebugAndSimulationService.simulateTransactionBundle({
+    path: {
+      owner: project.owner,
+      slug: project.slug,
+      chainId: options.chainId
+    },
+    body: body as never,
+    headers: context.headers
+  })
+  printOutput(options, unwrapApiResult(response))
+}
+
+async function runTraceBySimulation(simulationId: string, options: SimulationTraceOptions) {
+  await runTrace(options, (project, context) =>
+    DebugAndSimulationService.getCallTraceBySimulation({
+      path: {
+        owner: project.owner,
+        slug: project.slug,
+        chainId: options.chainId!,
+        simulationId
+      },
+      query: buildTraceQuery(options),
+      headers: context.headers
+    })
+  )
+}
+
+async function runTraceByBundle(bundleId: string, options: SimulationTraceOptions) {
+  await runTrace(options, (project, context) =>
+    DebugAndSimulationService.getCallTraceByBundle({
+      path: {
+        owner: project.owner,
+        slug: project.slug,
+        chainId: options.chainId!,
+        bundleId
+      },
+      query: buildTraceQuery(options),
+      headers: context.headers
+    })
+  )
+}
+
+async function runTraceByTransaction(txHash: string, options: SimulationTraceOptions) {
+  await runTrace(options, (project, context) =>
+    DebugAndSimulationService.getCallTraceByTransaction({
+      path: {
+        owner: project.owner,
+        slug: project.slug,
+        chainId: options.chainId!,
+        txHash
+      },
+      query: buildTraceQuery(options),
+      headers: context.headers
+    })
+  )
+}
+
+async function runTrace(
+  options: SimulationTraceOptions,
+  operation: (
+    project: Awaited<ReturnType<typeof resolveProjectRef>>,
+    context: ReturnType<typeof createApiContext>
+  ) => Promise<unknown>
+) {
+  if (!options.chainId) {
+    throw new CliError('Chain id is required. Use --chain-id <id>.')
+  }
+  const context = createApiContext(options)
+  const project = await resolveProjectRef(options, context, { ownerSlug: true })
+  const data = unwrapApiResult((await operation(project, context)) as never)
+  printOutput(options, data)
+}
+
+function buildTraceQuery(options: SimulationTraceOptions) {
+  return {
+    withInternalCalls: options.withInternalCalls,
+    disableOptimizer: options.disableOptimizer,
+    ignoreGasCost: options.ignoreGasCost
+  }
+}
+
+function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--host <host>', 'Override Sentio host')
+    .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
+    .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
+}
+
+function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--project <owner/slug>', 'Sentio project in <owner>/<slug> format')
+    .option('--owner <owner>', 'Sentio project owner')
+    .option('--name <name>', 'Sentio project name')
+    .option('--project-id <id>', 'Sentio project id')
+}
+
+function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--file <path>', 'Read request JSON or YAML from file')
+    .option('--stdin', 'Read request JSON or YAML from stdin')
+}
+
+function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+  return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
+}
+
+function withTraceOptions<T extends Command<any, any, any>>(command: T) {
+  return command
+    .option('--chain-id <id>', 'Chain id')
+    .option('--with-internal-calls', 'Fetch decoded trace with internal calls')
+    .option('--disable-optimizer', 'Disable optimizer for more accurate internal calls')
+    .option('--ignore-gas-cost', 'Ignore gas cost when optimizer is disabled')
+}
+
+function handleSimulationCommandError(error: unknown, command?: Command) {
+  if (
+    error instanceof CliError &&
+    (error.message.startsWith('Project is required.') ||
+      error.message.startsWith('Invalid project ') ||
+      error.message.startsWith('Provide --file or --stdin for simulation run') ||
+      error.message.startsWith('Chain id is required. Use --chain-id <id>.'))
+  ) {
+    console.error(error.message)
+    if (command) {
+      console.error()
+      command.outputHelp()
+    }
+    process.exit(1)
+  }
+  handleCommandError(error)
+}
+
+function printOutput(options: SimulationOptions, data: unknown) {
+  if (options.json && options.yaml) {
+    throw new CliError('Choose only one structured output format: --json or --yaml.')
+  }
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+  if (options.yaml) {
+    console.log(yaml.stringify(data).trimEnd())
+    return
+  }
+  console.log(formatOutput(data))
+}
+
+function formatOutput(data: unknown) {
+  if (data && typeof data === 'object' && Array.isArray((data as { simulations?: unknown[] }).simulations)) {
+    const simulations = (data as { simulations: Array<Record<string, unknown>> }).simulations
+    const lines = [`Simulations (${simulations.length})`]
+    for (const simulation of simulations) {
+      lines.push(formatSimulationLine(simulation))
+    }
+    return lines.join('\n')
+  }
+
+  if (data && typeof data === 'object' && 'simulation' in (data as Record<string, unknown>)) {
+    const simulation = (data as { simulation?: Record<string, unknown> }).simulation
+    return simulation ? formatSimulationDetails(simulation) : JSON.stringify(data, null, 2)
+  }
+
+  if (data && typeof data === 'object' && 'bundleId' in (data as Record<string, unknown>)) {
+    const bundle = data as { bundleId?: string; simulations?: Array<Record<string, unknown>>; error?: string }
+    const lines = [`Bundle: ${bundle.bundleId ?? '<bundle>'}`]
+    if (bundle.error) {
+      lines.push(`Error: ${bundle.error}`)
+    }
+    const simulations = Array.isArray(bundle.simulations) ? bundle.simulations : []
+    if (simulations.length > 0) {
+      lines.push(`Simulations (${simulations.length})`)
+      for (const simulation of simulations) {
+        lines.push(formatSimulationLine(simulation))
+      }
+    }
+    return lines.join('\n')
+  }
+
+  if (
+    data &&
+    typeof data === 'object' &&
+    ('contentType' in (data as Record<string, unknown>) || 'data' in (data as Record<string, unknown>))
+  ) {
+    const body = data as { contentType?: string; data?: string }
+    const lines = ['Trace']
+    if (body.contentType) {
+      lines.push(`Content-Type: ${body.contentType}`)
+    }
+    if (body.data) {
+      lines.push(body.data)
+    }
+    return lines.join('\n')
+  }
+
+  return JSON.stringify(data, null, 2)
+}
+
+function formatSimulationLine(simulation: Record<string, unknown>) {
+  const id = asString(simulation.id) ?? '<simulation>'
+  const label = asString(simulation.label)
+  const chainId =
+    asString(simulation.chainId) ??
+    asString((simulation.chainSpec as Record<string, unknown> | undefined)?.chainId) ??
+    '?'
+  const from = asString(simulation.from) ?? '?'
+  const to = asString(simulation.to) ?? '?'
+  return `- ${id}${label ? ` "${label}"` : ''} chain=${chainId} from=${from} to=${to}`
+}
+
+function formatSimulationDetails(simulation: Record<string, unknown>) {
+  const lines = [formatSimulationLine(simulation)]
+  if (asString(simulation.bundleId)) {
+    lines.push(`Bundle ID: ${asString(simulation.bundleId)}`)
+  }
+  if (asString(simulation.blockNumber)) {
+    lines.push(`Block: ${asString(simulation.blockNumber)}`)
+  }
+  if (asString(simulation.transactionIndex)) {
+    lines.push(`Transaction index: ${asString(simulation.transactionIndex)}`)
+  }
+  if (asString(simulation.value)) {
+    lines.push(`Value: ${asString(simulation.value)}`)
+  }
+  return lines.join('\n')
+}
+
+function parseInteger(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    throw new InvalidArgumentError('Not a number.')
+  }
+  return parsedValue
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,13 +11,26 @@ import { createGraphCommand } from './commands/graph.js'
 import { createUploadCommand } from './commands/upload.js'
 import { createBuildCommand, createGenCommand } from './commands/build.js'
 import { createAiCommand } from './commands/ai.js'
-import { getCliVersion, printVersions } from './utils.js'
+import { createDataCommand } from './commands/data.js'
+import { createProjectCommand } from './commands/project.js'
+import { createProcessorCommand } from './commands/processor.js'
+import { createAlertCommand } from './commands/alert.js'
+import { createPriceCommand } from './commands/price.js'
+import { createSimulationCommand } from './commands/simulation.js'
+import { createEndpointCommand } from './commands/endpoint.js'
+import { enableApiDebug } from './api.js'
+import { printVersions } from './utils.js'
 
 const program = new Command()
 
-program.name('sentio').description('Login & Manage your project files to Sentio.').version(getCliVersion())
+program.name('sentio').description('Login & Manage your project files to Sentio.')
+program.option('--debug', 'Print API requests for debugging')
 
 await printVersions()
+
+if (process.argv.includes('--debug')) {
+  enableApiDebug()
+}
 
 program.addCommand(createLoginCommand())
 program.addCommand(createCreateCommand())
@@ -30,5 +43,12 @@ program.addCommand(createUploadCommand())
 program.addCommand(createBuildCommand())
 program.addCommand(createGenCommand())
 program.addCommand(createAiCommand())
+program.addCommand(createDataCommand())
+program.addCommand(createProjectCommand())
+program.addCommand(createProcessorCommand())
+program.addCommand(createAlertCommand())
+program.addCommand(createPriceCommand())
+program.addCommand(createSimulationCommand())
+program.addCommand(createEndpointCommand())
 
 program.parse()

--- a/packages/cli/src/key.ts
+++ b/packages/cli/src/key.ts
@@ -6,38 +6,59 @@ const homeDir = os.homedir()
 const sentioDir = path.join(homeDir, '.sentio')
 const configFile = path.join(sentioDir, 'config.json')
 
+interface SentioHostConfig {
+  api_keys: string
+  access_token?: string
+  access_token_expires_at?: number // unix epoch seconds
+}
+
 interface SentioKeyConfig {
-  [key: string]: {
-    api_keys: string
+  [host: string]: SentioHostConfig
+}
+
+function readConfig(): SentioKeyConfig {
+  if (!fs.existsSync(sentioDir) || !fs.existsSync(configFile)) {
+    return {}
+  }
+  try {
+    return JSON.parse(fs.readFileSync(configFile, 'utf8')) as SentioKeyConfig
+  } catch {
+    return {}
   }
 }
 
-export function WriteKey(host: string, api_key: string) {
-  const sentioDir = path.join(homeDir, '.sentio')
+function writeConfig(config: SentioKeyConfig) {
   if (!fs.existsSync(sentioDir)) {
     fs.mkdirSync(sentioDir, { recursive: true })
   }
-  let config: SentioKeyConfig = {}
-  if (fs.existsSync(configFile)) {
-    const content = fs.readFileSync(configFile, 'utf8')
-    config = JSON.parse(content)
-  }
-  const hostConfig = config[host] || { api_keys: {} }
-  hostConfig.api_keys = api_key
-  config[host] = hostConfig
   fs.writeFileSync(configFile, JSON.stringify(config, null, 2))
 }
 
+export function WriteKey(host: string, api_key: string) {
+  const config = readConfig()
+  config[host] = { ...config[host], api_keys: api_key }
+  writeConfig(config)
+}
+
 export function ReadKey(host: string): string | undefined {
-  if (!fs.existsSync(sentioDir)) {
+  return readConfig()[host]?.api_keys
+}
+
+export function WriteAccessToken(host: string, token: string, expiresAt: number) {
+  const config = readConfig()
+  config[host] = { ...config[host], access_token: token, access_token_expires_at: expiresAt }
+  writeConfig(config)
+}
+
+export function ReadAccessToken(host: string): { token: string; expiresAt: number } | undefined {
+  const hostConfig = readConfig()[host]
+  if (!hostConfig?.access_token || hostConfig.access_token_expires_at === undefined) {
     return undefined
   }
-  const configFile = path.join(sentioDir, 'config.json')
-  if (fs.existsSync(configFile)) {
-    const content = fs.readFileSync(configFile, 'utf8')
-    const config = JSON.parse(content)
-    return config[host]?.api_keys
-  } else {
-    return undefined
-  }
+  return { token: hostConfig.access_token, expiresAt: hostConfig.access_token_expires_at }
+}
+
+export function isAccessTokenExpired(expiresAt: number): boolean {
+  // treat as expired 60 seconds early to avoid edge cases
+  return Date.now() / 1000 >= expiresAt - 60
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@mysten/sui':
         specifier: ~2.4.0
         version: 2.4.0(typescript@5.9.2)
+      '@sentio/api':
+        specifier: 1.0.4
+        version: 1.0.4
       '@sentio/chain':
         specifier: ~3.4.22
         version: 3.4.22
@@ -2487,6 +2490,9 @@ packages:
 
   '@sentio/api@1.0.2':
     resolution: {integrity: sha512-iKk0oMXfvNYQOFXH0jrdGze2wDuYt2GSEYz3uF4jrPeDXp0/es5JZJ4PG7mdET5MhCIWuMUqwQrY/NrL6xkF4Q==}
+
+  '@sentio/api@1.0.4':
+    resolution: {integrity: sha512-ai9HI1z1/w0KCinT9VT2JLzvyrG03ujd3dfTq+ksj4JxIlhzZb/86v0db1Grq4NNp9n2jG88aBgf7gf13g2kuQ==}
 
   '@sentio/bigdecimal@9.1.1-patch.3':
     resolution: {integrity: sha512-O5w8XdyeatUcwI+ZbpSw60/cXFPJk3NbpIupwMHfYmW8fpxpXyRbyGESNJNufWWrB6CadsWGh1R3rd7owvrmlw==}
@@ -7120,14 +7126,8 @@ snapshots:
 
   '@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.9.2)':
     dependencies:
-      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.9.2)
-      graphql: 16.11.0
-      typescript: 5.9.2
-
-  '@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.9.2)':
-    dependencies:
       '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.9.2)
-      graphql: 16.12.0
+      graphql: 16.11.0
       typescript: 5.9.2
 
   '@adraffy/ens-normalize@1.10.1': {}
@@ -7794,7 +7794,7 @@ snapshots:
       '@shikijs/types': 3.11.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@gql.tada/cli-utils@1.7.1(@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.9.2))(graphql@16.11.0)(typescript@5.9.2)':
+  '@gql.tada/cli-utils@1.7.1(@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.9.2))(graphql@16.11.0)(typescript@5.9.2)':
     dependencies:
       '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.9.2)
       '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.9.2)
@@ -7803,14 +7803,14 @@ snapshots:
 
   '@gql.tada/cli-utils@1.7.2(@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.9.2))(graphql@16.12.0)(typescript@5.9.2)':
     dependencies:
-      '@0no-co/graphqlsp': 1.12.16(graphql@16.12.0)(typescript@5.9.2)
+      '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.9.2)
       '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.9.2)
       graphql: 16.12.0
       typescript: 5.9.2
 
   '@gql.tada/internal@1.0.8(graphql@16.11.0)(typescript@5.9.2)':
     dependencies:
-      '@0no-co/graphql.web': 1.0.7(graphql@16.11.0)
+      '@0no-co/graphql.web': 1.0.7(graphql@16.12.0)
       graphql: 16.11.0
       typescript: 5.9.2
 
@@ -8903,6 +8903,10 @@ snapshots:
       yargs: 17.7.2
 
   '@sentio/api@1.0.2':
+    dependencies:
+      '@hey-api/client-fetch': 0.8.3
+
+  '@sentio/api@1.0.4':
     dependencies:
       '@hey-api/client-fetch': 0.8.3
 
@@ -11177,7 +11181,7 @@ snapshots:
     dependencies:
       '@0no-co/graphql.web': 1.0.7(graphql@16.11.0)
       '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.9.2)
-      '@gql.tada/cli-utils': 1.7.1(@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.9.2))(graphql@16.11.0)(typescript@5.9.2)
+      '@gql.tada/cli-utils': 1.7.1(@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.9.2))(graphql@16.11.0)(typescript@5.9.2)
       '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -11188,7 +11192,7 @@ snapshots:
   gql.tada@1.9.0(graphql@16.12.0)(typescript@5.9.2):
     dependencies:
       '@0no-co/graphql.web': 1.0.7(graphql@16.12.0)
-      '@0no-co/graphqlsp': 1.12.16(graphql@16.12.0)(typescript@5.9.2)
+      '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.9.2)
       '@gql.tada/cli-utils': 1.7.2(@0no-co/graphqlsp@1.12.16(graphql@16.12.0)(typescript@5.9.2))(graphql@16.12.0)(typescript@5.9.2)
       '@gql.tada/internal': 1.0.8(graphql@16.12.0)(typescript@5.9.2)
       typescript: 5.9.2


### PR DESCRIPTION
Summary
- add CLI support for endpoint create/get/list/delete/test, wiring new API calls and handling project defaults
- extend related command tests and update CLI metadata to expose the new functionality
- refresh docs and lockfile to reflect the added support

Testing
- Not run (not requested)