### PR TITLE
fix(cli): use correct proto field name for required_chains

### DIFF
--- a/packages/cli/src/uploader.ts
+++ b/packages/cli/src/uploader.ts
@@ -160,7 +160,7 @@ export abstract class BatchUploader {
         rollback,
         numWorkers,
         sentio_network: this.options.sentioNetwork,
-        required_chain_ids: this.options.requiredChainIds
+        required_chains: this.options.requiredChainIds
       })
     })
 


### PR DESCRIPTION
## Summary
- CLI was sending `required_chain_ids` in the `FinishBatchUpload` request body, but the proto field is `required_chains` ([processor_service.proto#L322](https://github.com/sentioxyz/sentio-core/blob/main/service/processor/protos/processor_service.proto#L322)).
- grpc-gateway silently dropped the unknown field, so the server received an empty array. The result: processors uploaded to Sentio Network were registered on-chain with an empty `requireChains` array, breaking allocation matching against indexer chain capabilities.

## Repro
```
yarn sentio upload --sentio-network testnet --required-chain-id 8453
```
On-chain `ProcessorRegistry.requireChains` for the resulting processor was empty (e.g. tx `0xc87da1e9f19ea785e21ab6af9cdfc8b8eccbfefc84e8bf6151622d29ff32c260`).

## Test plan
- [ ] Re-run `yarn sentio upload --sentio-network testnet --required-chain-id 8453` against testnet
- [ ] Verify resulting on-chain processor has `requireChains = [8453]` via `getRequireChains`
- [ ] Verify Controller allocates the processor to a Base-capable indexer

🤖 Generated with [Claude Code](https://claude.com/claude-code)