### PR TITLE
fix iota coin list init and dedupe concurrent coin list loads

### DIFF
--- a/packages/sdk/src/iota/ext/coin.ts
+++ b/packages/sdk/src/iota/ext/coin.ts
@@ -9,16 +9,32 @@ import { CoinMetadata } from '@iota/iota-sdk/client'
 
 const WHITELISTED_COINS = new Map<string, BaseCoinInfo>()
 
-export async function initCoinList() {
-  let list = DEFAULT_LIST.coinlist
-  try {
-    const resp = await fetch('https://raw.githubusercontent.com/solflare-wallet/iota-coinlist/master/sui-coinlist.json')
-    list = ((await resp.json()) as any).coinlist
-  } catch (e) {
-    console.warn("Can't not fetch newest coin list, use default list")
-  }
+let initiated = false
+let initPromise: Promise<void> | null = null
 
-  setCoinList(list)
+export async function initCoinList() {
+  if (initiated) {
+    return
+  }
+  if (initPromise) {
+    return initPromise
+  }
+  initPromise = (async () => {
+    let list = DEFAULT_LIST.coinlist
+    try {
+      const resp = await fetch(
+        'https://raw.githubusercontent.com/solflare-wallet/iota-coinlist/master/sui-coinlist.json',
+        { signal: AbortSignal.timeout(30_000) }
+      )
+      list = ((await resp.json()) as any).coinlist
+    } catch (e) {
+      console.warn("Can't not fetch newest coin list, use default list")
+    }
+
+    setCoinList(list)
+    initiated = true
+  })()
+  return initPromise
 }
 
 export interface IotaCoinInfo {

--- a/packages/sdk/src/sui/ext/coin.ts
+++ b/packages/sdk/src/sui/ext/coin.ts
@@ -10,20 +10,30 @@ import { CoinMetadata } from '@mysten/sui/jsonRpc'
 const WHITELISTED_COINS = new Map<string, BaseCoinInfo>()
 
 let initiated = false
+let initPromise: Promise<void> | null = null
+
 export async function initCoinList() {
   if (initiated) {
     return
   }
-  let list = DEFAULT_LIST.coinlist
-  try {
-    const resp = await fetch('https://raw.githubusercontent.com/solflare-wallet/sui-coinlist/master/sui-coinlist.json')
-    list = ((await resp.json()) as any).coinlist
-  } catch (e) {
-    console.warn("Can't not fetch newest coin list, use default list")
+  if (initPromise) {
+    return initPromise
   }
+  initPromise = (async () => {
+    let list = DEFAULT_LIST.coinlist
+    try {
+      const resp = await fetch('https://raw.githubusercontent.com/solflare-wallet/sui-coinlist/master/sui-coinlist.json', {
+        signal: AbortSignal.timeout(30_000)
+      })
+      list = ((await resp.json()) as any).coinlist
+    } catch (e) {
+      console.warn("Can't not fetch newest coin list, use default list")
+    }
 
-  setCoinList(list)
-  initiated = true
+    setCoinList(list)
+    initiated = true
+  })()
+  return initPromise
 }
 
 export interface SuiCoinInfo {


### PR DESCRIPTION
## what changed

- **iota**: \initCoinList()\ had no \initiated\ guard (unlike sui), so every call re-fetched the remote coin list and rebuilt the whitelist. it now runs the remote load once, then no-ops like sui.

- **sui & iota**: concurrent \wait initCoinList()\ could each start a fetch before \initiated\ was set. a shared promise dedupes those into one in-flight load.

- **sui & iota**: coin list fetch uses \AbortSignal.timeout(30s)\ so a stuck github response cannot block indexer startup indefinitely.

made by mooncitydev
