### PR TITLE
fix(cli): improve version flag handling and support numeric version s…

### DIFF
--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -559,7 +559,8 @@ function handleDashboardCommandError(error: unknown, command?: Command) {
       error.message.startsWith('Invalid metric aggregation') ||
       error.message.startsWith('Invalid filter') ||
       error.message.startsWith('Invalid metric selector') ||
-      error.message.startsWith('Invalid time range value'))
+      error.message.startsWith('Invalid time range value') ||
+      error.message.startsWith('Unknown function "'))
   ) {
     console.error(error.message)
     if (command) {

--- a/packages/cli/src/commands/data.ts
+++ b/packages/cli/src/commands/data.ts
@@ -16,6 +16,62 @@ import {
 } from '../api.js'
 
 const DEFAULT_RANGE_STEP = 3600
+
+// Valid function names sourced from sentio/app/lib/functions.ts
+const VALID_METRIC_FUNCTIONS: ReadonlySet<string> = new Set([
+  // Math
+  'abs',
+  'ceil',
+  'floor',
+  'round',
+  'log2',
+  'log10',
+  'ln',
+  // Rollup
+  'rollup_avg',
+  'rollup_count',
+  'rollup_last',
+  'rollup_max',
+  'rollup_min',
+  'rollup_sum',
+  'rollup_delta',
+  // Aggregate Over Time
+  'avg_over_time',
+  'count_over_time',
+  'last_over_time',
+  'max_over_time',
+  'min_over_time',
+  'sum_over_time',
+  'delta_over_time',
+  // Rate
+  'rate',
+  'irate',
+  'delta',
+  'moving_delta',
+  // Rank
+  'topk',
+  'bottomk',
+  // Time
+  'timestamp',
+  'day_of_year',
+  'day_of_month',
+  'day_of_week',
+  'year',
+  'month',
+  'hour',
+  'minute',
+  // TimeShift
+  'before',
+  'after'
+])
+
+const VALID_EVENT_FUNCTIONS: ReadonlySet<string> = new Set([
+  // Rank
+  'topk',
+  'bottomk',
+  // Delta
+  'delta'
+])
 interface CommonDataOptions {
   host?: string
   apiKey?: string
@@ -113,7 +169,7 @@ export function buildEventsInsightQueryBody(
           aggregation: buildEventAggregation(options.aggr),
           selectorExpr: buildSelectorExpr(options.filter),
           groupBy: normalizeListOption(options.groupBy),
-          functions: buildFunctions(options.func),
+          functions: buildFunctions(options.func, VALID_EVENT_FUNCTIONS),
           disabled: false
         }
       }
@@ -148,7 +204,7 @@ export function buildMetricsInsightQueryBody(
           query,
           labelSelector: buildMetricLabelSelector(options.filter),
           aggregate: buildMetricAggregate(options.aggr, options.groupBy),
-          functions: buildFunctions(options.func),
+          functions: buildFunctions(options.func, VALID_METRIC_FUNCTIONS),
           disabled: false
         }
       }
@@ -584,7 +640,8 @@ function shouldShowHelpForDataCommandError(error: CliError) {
     error.message.startsWith('Provide --query, --result, --file, or --stdin.') ||
     error.message.startsWith('Use only one of --query or --result.') ||
     error.message.startsWith('--async only works with --query.') ||
-    error.message.startsWith('Execution id is required.')
+    error.message.startsWith('Execution id is required.') ||
+    error.message.startsWith('Unknown function "')
   )
 }
 
@@ -730,8 +787,14 @@ function parseAnyValue(rawValue: string) {
   return { stringValue: unquotedValue }
 }
 
-function buildFunctions(functions?: string[]) {
-  return normalizeListOption(functions).map(parseFunctionCall)
+function buildFunctions(functions?: string[], validNames?: ReadonlySet<string>) {
+  return normalizeListOption(functions).map((f) => {
+    const parsed = parseFunctionCall(f)
+    if (validNames && !validNames.has(parsed.name)) {
+      throw new CliError(`Unknown function "${parsed.name}". Valid functions: ${[...validNames].sort().join(', ')}.`)
+    }
+    return parsed
+  })
 }
 
 function parseFunctionCall(value: string) {

--- a/packages/cli/src/commands/processor.ts
+++ b/packages/cli/src/commands/processor.ts
@@ -27,7 +27,7 @@ interface ProcessorOptions {
 }
 
 interface ProcessorStatusOptions extends ProcessorOptions {
-  version?: string
+  version?: string | number
 }
 
 interface ProcessorSourceOptions extends ProcessorOptions {
@@ -60,7 +60,11 @@ function createProcessorStatusCommand() {
     withSharedProjectOptions(withAuthOptions(new Command('status').description('Get processor status')))
   )
     .showHelpAfterError()
-    .option('--version <selector>', 'Version selector: active, pending, or all')
+    .option(
+      '--version <selector>',
+      'Version selector: active, pending, all, or a numeric version number',
+      parseVersionSelector
+    )
     .action(async (options, command) => {
       try {
         await runProcessorStatus(options)
@@ -176,22 +180,19 @@ async function runProcessorStatus(options: ProcessorStatusOptions) {
   const context = createApiContext(options)
   const project = await resolveProjectRef(options, context, { ownerSlug: true })
   const requestedVersion = normalizeVersionSelector(options.version)
+  const apiVersion = typeof requestedVersion === 'number' ? 'ALL' : (requestedVersion ?? 'ALL')
   const response = await ProcessorService.getProcessorStatusV2({
     path: {
       owner: project.owner,
       slug: project.slug
     },
     query: {
-      version: requestedVersion ?? 'ALL'
+      version: apiVersion
     },
     headers: context.headers
   })
   const data = unwrapApiResult(response)
-  if (!options.json) {
-    printOutput(options, shapeProcessorStatusOutput(data, requestedVersion))
-    return
-  }
-  printOutput(options, data)
+  printOutput(options, shapeProcessorStatusOutput(data, requestedVersion))
 }
 
 async function runProcessorSource(options: ProcessorSourceOptions) {
@@ -501,7 +502,7 @@ function handleProcessorCommandError(error: unknown, command?: Command) {
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||
       error.message.startsWith('Invalid project ') ||
-      error.message.startsWith('Invalid version selector ') ||
+      error.message.startsWith('Invalid version selector') ||
       error.message.startsWith('Source file not found:'))
   ) {
     console.error(error.message)
@@ -610,15 +611,26 @@ function formatOutput(data: unknown) {
   return JSON.stringify(data, null, 2)
 }
 
-function normalizeVersionSelector(value?: string): 'ACTIVE' | 'PENDING' | 'ALL' | undefined {
-  if (!value) {
+function normalizeVersionSelector(value?: string | number): 'ACTIVE' | 'PENDING' | 'ALL' | number | undefined {
+  if (value === undefined) {
     return undefined
+  }
+  if (typeof value === 'number') {
+    return value
   }
   const normalized = value.toUpperCase()
   if (normalized === 'ACTIVE' || normalized === 'PENDING' || normalized === 'ALL') {
     return normalized
   }
-  throw new CliError(`Invalid version selector "${value}". Use active, pending, or all.`)
+  throw new CliError(`Invalid version selector "${value}". Use active, pending, all, or a version number.`)
+}
+
+function parseVersionSelector(value: string): string | number {
+  const num = Number.parseInt(value, 10)
+  if (!Number.isNaN(num) && String(num) === value) {
+    return num
+  }
+  return value
 }
 
 function parseInteger(value: string) {
@@ -639,7 +651,7 @@ function asNumber(value: unknown) {
 
 function shapeProcessorStatusOutput(
   data: { processors?: Array<Record<string, unknown>> },
-  versionSelector?: 'ACTIVE' | 'PENDING' | 'ALL'
+  versionSelector?: 'ACTIVE' | 'PENDING' | 'ALL' | number
 ) {
   const processors = Array.isArray(data.processors) ? data.processors : []
   if (versionSelector === 'ALL') {
@@ -649,6 +661,12 @@ function shapeProcessorStatusOutput(
     return {
       ...data,
       processors: processors.filter((processor) => asString(processor.versionState) === versionSelector)
+    }
+  }
+  if (typeof versionSelector === 'number') {
+    return {
+      ...data,
+      processors: processors.filter((processor) => asNumber(processor.version) === versionSelector)
     }
   }
   return {

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -7,7 +7,7 @@ export function createVersionCommand() {
   })
 }
 
-function version() {
+export function version() {
   console.log('CLI Version: ', getCliVersion())
   const sdkVersion = getSdkVersion()
   if (sdkVersion) {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,185 @@
+import { describe, test } from 'node:test'
+import { expect } from 'chai'
+import { execFile } from 'node:child_process'
+import http from 'node:http'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+describe('sentio cli entrypoint', () => {
+  test('treats top-level --version as an alias for the version command', async () => {
+    const execOptions = {
+      cwd: new URL('..', import.meta.url),
+      env: {
+        ...process.env,
+        NO_COLOR: '1'
+      }
+    }
+    const [{ stdout: flagOutput }, { stdout: commandOutput }] = await Promise.all([
+      execFileAsync('pnpm', ['exec', 'tsx', 'src/index.ts', '--version'], execOptions),
+      execFileAsync('pnpm', ['exec', 'tsx', 'src/index.ts', 'version'], execOptions)
+    ])
+
+    expect(flagOutput).equal(commandOutput)
+  })
+
+  test('does not treat subcommand --version values as the top-level version flag', async () => {
+    const requests: string[] = []
+    const server = http.createServer((req, res) => {
+      requests.push(req.url ?? '')
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ processors: [] }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected local test server address')
+      }
+
+      await execFileAsync(
+        'pnpm',
+        [
+          'exec',
+          'tsx',
+          'src/index.ts',
+          'processor',
+          'status',
+          '--host',
+          `http://127.0.0.1:${address.port}`,
+          '--api-key',
+          'test-key',
+          '--project',
+          'sentio/coinbase',
+          '--version',
+          'all',
+          '--json'
+        ],
+        {
+          cwd: new URL('..', import.meta.url),
+          env: {
+            ...process.env,
+            NO_COLOR: '1'
+          }
+        }
+      )
+
+      expect(requests).deep.equal(['/v1/processors/sentio/coinbase/status?version=ALL'])
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
+  test('processor status --version <number> fetches all versions and filters client-side', async () => {
+    const requests: string[] = []
+    const server = http.createServer((req, res) => {
+      requests.push(req.url ?? '')
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          processors: [
+            { version: 42, versionState: 'OBSOLETE', processorStatus: { state: 'STOPPED' } },
+            { version: 43, versionState: 'ACTIVE', processorStatus: { state: 'RUNNING' } }
+          ]
+        })
+      )
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected local test server address')
+      }
+
+      const { stdout } = await execFileAsync(
+        'pnpm',
+        [
+          'exec',
+          'tsx',
+          'src/index.ts',
+          'processor',
+          'status',
+          '--host',
+          `http://127.0.0.1:${address.port}`,
+          '--api-key',
+          'test-key',
+          '--project',
+          'sentio/coinbase',
+          '--version',
+          '42',
+          '--json'
+        ],
+        {
+          cwd: new URL('..', import.meta.url),
+          env: {
+            ...process.env,
+            NO_COLOR: '1'
+          }
+        }
+      )
+
+      expect(requests).deep.equal(['/v1/processors/sentio/coinbase/status?version=ALL'])
+      const jsonStart = stdout.indexOf('{')
+      const result = JSON.parse(stdout.slice(jsonStart))
+      expect(result.processors).to.have.lengthOf(1)
+      expect(result.processors[0].version).equal(42)
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
+  test('preserves numeric subcommand --version values', async () => {
+    const requests: string[] = []
+    const server = http.createServer((req, res) => {
+      requests.push(req.url ?? '')
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ sourceFiles: [] }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected local test server address')
+      }
+
+      await execFileAsync(
+        'pnpm',
+        [
+          'exec',
+          'tsx',
+          'src/index.ts',
+          'processor',
+          'source',
+          '--host',
+          `http://127.0.0.1:${address.port}`,
+          '--api-key',
+          'test-key',
+          '--project',
+          'sentio/coinbase',
+          '--version',
+          '67'
+        ],
+        {
+          cwd: new URL('..', import.meta.url),
+          env: {
+            ...process.env,
+            NO_COLOR: '1'
+          }
+        }
+      )
+
+      expect(requests).deep.equal(['/v1/processors/sentio/coinbase/source_files?version=67'])
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+})

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,7 @@
 import { Command } from '@commander-js/extra-typings'
 import { createLoginCommand } from './commands/login.js'
 import { createCreateCommand } from './commands/create.js'
-import { createVersionCommand } from './commands/version.js'
+import { createVersionCommand, version } from './commands/version.js'
 import { createTestCommand } from './commands/test.js'
 import { createAddCommand } from './commands/add.js'
 import { createCompileCommand } from './commands/compile.js'
@@ -32,6 +32,11 @@ await printVersions()
 
 if (process.argv.includes('--debug')) {
   enableApiDebug()
+}
+
+if (process.argv.length === 3 && process.argv[2] === '--version') {
+  version()
+  process.exit(0)
 }
 
 program.addCommand(createLoginCommand())


### PR DESCRIPTION
…electors for processor commands

- Treat top-level --version as an alias for the version command
- Support numeric values for processor status/source --version option
- Filter processor status output client-side by version number when specified
- Add tests to verify version flag and selector behaviors