### PR TITLE
chore(cli): point testnet config at redeployed contracts

### DIFF
--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -15,9 +15,9 @@ interface SentioNetworkConfig {
 
 const TESTNET_CONFIG: SentioNetworkConfig = {
   chainId: 7892101,
-  rpcUrl: 'https://testnet.sentio.xyz',
+  rpcUrl: 'https://sentio-testnet.rpc.sentio.xyz',
   explorerUrl: 'https://testnet-explorer.sentio.xyz',
-  addressBookAddress: '0x17d5aF5Ed9C2558B802bEfcCc5a94C36dE95BB0B'
+  addressBookAddress: '0x11cDDF46f16925aa630Af9D5158028E56309868f'
 }
 
 export function getSentioNetworkConfig(network: string): SentioNetworkConfig {


### PR DESCRIPTION
## Summary

After the 2026-05-06 testnet redeploy onto the bridged SENTIO token, the prior AddressBook \`0x17d5aF5…\` has no code on the live RPC, and \`testnet.sentio.xyz\` is currently offline (\`sentio-testnet.rpc.sentio.xyz\` is the active hostname; \`testnet.sentio.xyz\` will be re-enabled later as an alias).

This flips the cli's hardcoded testnet config:

| Field | Before | After |
|---|---|---|
| \`addressBookAddress\` | \`0x17d5aF5Ed9C2558B802bEfcCc5a94C36dE95BB0B\` (no code) | \`0x11cDDF46f16925aa630Af9D5158028E56309868f\` |
| \`rpcUrl\` | \`https://testnet.sentio.xyz\` (offline) | \`https://sentio-testnet.rpc.sentio.xyz\` |

\`explorerUrl\` is unchanged — it's live and was used for \`forge verify-contract\`.

All other contract addresses (ProcessorRegistry, Controller, ST token, Billing) are resolved at runtime via \`AddressBook.getAddress(string)\` so no other hardcoded addresses needed flipping.

## Test plan

- [ ] \`sentio upload --network testnet\` resolves module proxies (logs print non-zero ProcessorRegistry / Controller / Billing / ST Token)
- [ ] \`createProcessor\` / \`startProcessor\` / \`stopProcessor\` / \`deleteProcessor\` succeed end-to-end after the production helm cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)