### PR TITLE
feat(cli): owner+operator delegation for --no-platform upload

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -20,6 +20,7 @@ import {
   requirePrivateKey,
   checkSTBalance,
   checkBillingBalance,
+  isOperatorOnChain,
   uploadToIPFS,
   createProcessorOnChain,
   startProcessorOnChain,
@@ -28,6 +29,7 @@ import {
   getProcessorOnChain,
   deleteProcessorOnChain
 } from '../network.js'
+import { ethers } from 'ethers'
 import { Auth, DefaultBatchUploader, FileType, IPFSBatchUploader, WalrusBatchUploader } from '../uploader.js'
 export { type Auth } from '../uploader.js'
 
@@ -43,7 +45,10 @@ function myParseInt(value: string, dummyPrevious: number): number {
 export function createUploadCommand() {
   return new Command('upload')
     .description('Upload processor to Sentio')
-    .option('--owner <owner>', '(Optional) Override Project owner')
+    .option(
+      '--owner <owner>',
+      "(Optional) Project owner. Platform mode: project owner username. --no-platform mode: on-chain owner address (0x...) — $PRIVATE_KEY then signs as an operator on the owner's behalf, requires Permissions.addOperator beforehand."
+    )
     .option('--name <name>', '(Optional) Override Project name')
     .option(
       '--continue-from <version>',
@@ -102,21 +107,53 @@ async function runNoPlatformUpload(
   const network = options.sentioNetwork || 'testnet'
   const networkConfig = getSentioNetworkConfig(network)
 
-  // Step 1: Require PRIVATE_KEY
+  // Step 1: Require PRIVATE_KEY (operator key when --owner is set, otherwise the owner's own key)
   const privateKey = requirePrivateKey()
   const wallet = getWalletFromPrivateKey(privateKey)
   const walletAddress = wallet.address
+
+  // Operator mode: --owner is the on-chain owner address; PRIVATE_KEY signs as operator on its behalf.
+  let ownerOverride: string | undefined
+  if (options.owner) {
+    if (!ethers.isAddress(options.owner)) {
+      console.error(chalk.red(`Invalid --owner: "${options.owner}" is not a valid 0x-prefixed Ethereum address.`))
+      process.exit(1)
+    }
+    ownerOverride = ethers.getAddress(options.owner)
+  }
+  const effectiveOwner = ownerOverride ?? walletAddress
 
   // Step 2: Resolve contract addresses via AddressBook
   console.log(chalk.blue('Resolving contract addresses from AddressBook...'))
   const addresses = await resolveNetworkAddresses(networkConfig)
 
-  // Step 3: Check ST balance and Billing balance, then confirm
+  // Step 2.5: Pre-flight check that operator is registered for this owner.
+  if (ownerOverride) {
+    const isOp = await isOperatorOnChain(networkConfig, addresses, ownerOverride, walletAddress)
+    if (!isOp) {
+      console.error(
+        chalk.red(
+          `Operator ${walletAddress} is not authorized for owner ${ownerOverride}.\n` +
+            `The owner must call Permissions.addOperator(${walletAddress}) first.`
+        )
+      )
+      process.exit(1)
+    }
+  }
+
+  // Step 3: Check ST balance and Billing balance (always against the owner — operator just submits txs)
   const [stBalance, billingBalance] = await Promise.all([
-    checkSTBalance(networkConfig, addresses, walletAddress),
-    checkBillingBalance(networkConfig, addresses, walletAddress)
+    checkSTBalance(networkConfig, addresses, effectiveOwner),
+    checkBillingBalance(networkConfig, addresses, effectiveOwner)
   ])
-  const confirmed = await confirmNoPlatformUpload(walletAddress, stBalance, billingBalance, addresses, networkConfig)
+  const confirmed = await confirmNoPlatformUpload(
+    walletAddress,
+    stBalance,
+    billingBalance,
+    addresses,
+    networkConfig,
+    ownerOverride
+  )
   if (!confirmed) {
     console.log('Upload cancelled.')
     process.exit(0)
@@ -179,11 +216,13 @@ async function runNoPlatformUpload(
 
   if (existingProcessor) {
     const existingOwner = existingProcessor.owner.toLowerCase()
-    const currentWallet = wallet.address.toLowerCase()
+    const expectedOwner = effectiveOwner.toLowerCase()
 
-    if (existingOwner === currentWallet) {
-      // Same owner — prompt to replace
-      console.log(chalk.yellow(`Processor "${processorId}" already exists (owned by you).`))
+    if (existingOwner === expectedOwner) {
+      // Same owner — prompt to replace. In operator mode the operator is allowed to
+      // stop+delete via the contract's isProcessorAdmin check.
+      const ownedBy = ownerOverride ? `owned by ${ownerOverride}` : 'owned by you'
+      console.log(chalk.yellow(`Processor "${processorId}" already exists (${ownedBy}).`))
       const shouldReplace = await confirm(`Replace existing processor "${processorId}"?`)
       if (!shouldReplace) {
         console.log('Upload cancelled.')
@@ -194,9 +233,10 @@ async function runNoPlatformUpload(
       await deleteProcessorOnChain(networkConfig, addresses, wallet, processorId)
     } else {
       // Different owner — prompt to rename
+      const expectedLabel = ownerOverride ? `expected owner ${ownerOverride}` : `your wallet ${wallet.address}`
       console.log(
         chalk.yellow(
-          `Processor "${processorId}" already exists and is owned by ${existingProcessor.owner} (not your wallet ${wallet.address}).`
+          `Processor "${processorId}" already exists and is owned by ${existingProcessor.owner} (not ${expectedLabel}).`
         )
       )
       const randomSuffix = Math.random().toString(36).substring(2, 8)
@@ -215,7 +255,16 @@ async function runNoPlatformUpload(
   }
 
   // Step 8: Create processor on-chain
-  await createProcessorOnChain(networkConfig, addresses, wallet, processorId, cid, requiredChainIds, sdkVersion)
+  await createProcessorOnChain(
+    networkConfig,
+    addresses,
+    wallet,
+    processorId,
+    cid,
+    requiredChainIds,
+    sdkVersion,
+    ownerOverride
+  )
 
   // Step 9: Start processor on-chain
   await startProcessorOnChain(networkConfig, addresses, wallet, processorId)

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -40,9 +40,16 @@ const ADDRESS_BOOK_ABI = [
   'function getAddress(bytes32 id) view returns (address)'
 ]
 
-// ProcessorRegistry: createProcessor, getProcessor, deleteProcessor
+// ProcessorRegistry: createProcessor (self + operator overloads), getProcessor, deleteProcessor
 const PROCESSOR_REGISTRY_ABI = [
   `function createProcessor(
+    string id,
+    tuple(uint8 sourceType, string ipfsCid) source,
+    tuple(string chainId, bool enableRpc, bool enableTrace)[] requireChains,
+    string sdkVersion
+  ) returns (string)`,
+  `function createProcessor(
+    address owner,
     string id,
     tuple(uint8 sourceType, string ipfsCid) source,
     tuple(string chainId, bool enableRpc, bool enableTrace)[] requireChains,
@@ -74,6 +81,9 @@ const CONTROLLER_ABI = [
 // Databases:  getProcessorDatabases
 const DATABASES_ABI = ['function getProcessorDatabases(string processorId) view returns (string[])']
 
+// Permissions: isOperator (used to pre-check operator delegation before submitting tx)
+const PERMISSIONS_ABI = ['function isOperator(address account, address operator) view returns (bool)']
+
 // ERC20: balanceOf + approve
 const ERC20_ABI = [
   'function balanceOf(address account) view returns (uint256)',
@@ -91,7 +101,8 @@ const ADDRESS_BOOK_KEYS = {
   controller: 'controller',
   token: 'sentio_token',
   billing: 'billing',
-  databases: 'databases'
+  databases: 'databases',
+  permissions: 'permissions'
 } as const
 
 interface ResolvedAddresses {
@@ -101,6 +112,7 @@ interface ResolvedAddresses {
   token: string
   billing: string
   databases: string
+  permissions: string
 }
 
 let cachedAddresses: ResolvedAddresses | undefined
@@ -130,12 +142,13 @@ export async function resolveNetworkAddresses(config: SentioNetworkConfig): Prom
     }
   }
 
-  const [processorRegistry, controller, token, billing, databases] = await Promise.all([
+  const [processorRegistry, controller, token, billing, databases, permissions] = await Promise.all([
     resolveAddress(ADDRESS_BOOK_KEYS.processorRegistry),
     resolveAddress(ADDRESS_BOOK_KEYS.controller),
     resolveAddress(ADDRESS_BOOK_KEYS.token),
     resolveAddress(ADDRESS_BOOK_KEYS.billing),
-    resolveAddress(ADDRESS_BOOK_KEYS.databases)
+    resolveAddress(ADDRESS_BOOK_KEYS.databases),
+    resolveAddress(ADDRESS_BOOK_KEYS.permissions)
   ])
 
   console.log(chalk.gray(`ProcessorRegistry: ${processorRegistry}`))
@@ -143,8 +156,17 @@ export async function resolveNetworkAddresses(config: SentioNetworkConfig): Prom
   console.log(chalk.gray(`ST Token:          ${token}`))
   console.log(chalk.gray(`Billing:           ${billing}`))
   console.log(chalk.gray(`Databases:         ${databases}`))
+  console.log(chalk.gray(`Permissions:       ${permissions}`))
 
-  cachedAddresses = { addressBook: addressBookAddr, processorRegistry, controller, token, billing, databases }
+  cachedAddresses = {
+    addressBook: addressBookAddr,
+    processorRegistry,
+    controller,
+    token,
+    billing,
+    databases,
+    permissions
+  }
   return cachedAddresses
 }
 
@@ -194,6 +216,17 @@ export async function checkBillingBalance(
     // Billing contract may revert for accounts that have never deposited
     return 0n
   }
+}
+
+export async function isOperatorOnChain(
+  config: SentioNetworkConfig,
+  addresses: ResolvedAddresses,
+  owner: string,
+  operator: string
+): Promise<boolean> {
+  const provider = new ethers.JsonRpcProvider(config.rpcUrl)
+  const permissions = new ethers.Contract(addresses.permissions, PERMISSIONS_ABI, provider)
+  return await permissions.isOperator(owner, operator)
 }
 
 // --- IPFS Upload ---
@@ -349,7 +382,8 @@ export async function createProcessorOnChain(
   processorId: string,
   ipfsCid: string,
   requiredChainIds: string[],
-  sdkVersion: string
+  sdkVersion: string,
+  ownerOverride?: string
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(config.rpcUrl)
   const signer = wallet.connect(provider)
@@ -372,12 +406,26 @@ export async function createProcessorOnChain(
   console.log(chalk.gray(`  IPFS CID:     ${ipfsCid}`))
   console.log(chalk.gray(`  Chains:        ${requiredChainIds.join(', ')}`))
   console.log(chalk.gray(`  SDK Version:   ${sdkVersion}`))
+  if (ownerOverride) {
+    console.log(chalk.gray(`  Owner:         ${ownerOverride} (operator: ${wallet.address})`))
+  }
 
-  const tx = await submitAndWait(
-    config.explorerUrl,
-    'createProcessor',
-    registry.createProcessor(processorId, source, requireChains, sdkVersion)
-  )
+  // ethers v6 disambiguates overloads by full signature when both are present.
+  const txPromise: Promise<ethers.TransactionResponse> = ownerOverride
+    ? registry['createProcessor(address,string,(uint8,string),(string,bool,bool)[],string)'](
+        ownerOverride,
+        processorId,
+        source,
+        requireChains,
+        sdkVersion
+      )
+    : registry['createProcessor(string,(uint8,string),(string,bool,bool)[],string)'](
+        processorId,
+        source,
+        requireChains,
+        sdkVersion
+      )
+  const tx = await submitAndWait(config.explorerUrl, 'createProcessor', txPromise)
   console.log(chalk.green(`Processor created. Tx: ${config.explorerUrl}/tx/${tx.hash}`))
   return tx.hash
 }
@@ -430,26 +478,34 @@ export async function confirmNoPlatformUpload(
   stBalance: bigint,
   billingBalance: bigint,
   addresses: ResolvedAddresses,
-  networkConfig: SentioNetworkConfig
+  networkConfig: SentioNetworkConfig,
+  ownerOverride?: string
 ): Promise<boolean> {
   const formattedST = ethers.formatEther(stBalance)
   const formattedBilling = ethers.formatEther(billingBalance)
   console.log()
   console.log(chalk.blue('=== Sentio Network Direct Upload (No Platform) ==='))
-  console.log(chalk.white(`  Address:         ${walletAddress}`))
+  if (ownerOverride) {
+    console.log(chalk.white(`  Owner:           ${ownerOverride}`))
+    console.log(chalk.white(`  Operator:        ${walletAddress}`))
+  } else {
+    console.log(chalk.white(`  Address:         ${walletAddress}`))
+  }
   console.log(chalk.white(`  ST Balance:      ${formattedST} ST`))
   console.log(chalk.white(`  Billing Balance: ${formattedBilling} ST`))
 
   if (billingBalance === 0n) {
+    const who = ownerOverride ? `the owner (${ownerOverride})` : 'you'
+    const keyHint = ownerOverride ? "<owner's private key>" : '$PRIVATE_KEY'
     console.log()
     console.log(
       chalk.yellow(
-        '  ⚠ Your Billing balance is 0. Indexing fees are charged from the Billing contract.\n' +
-          '    You must deposit ST tokens into the Billing contract before your processor can run.\n' +
-          '    Example (replace 100 with your desired ST amount):\n' +
+        `  ⚠ ${ownerOverride ? "Owner's" : 'Your'} Billing balance is 0. Indexing fees are charged from the Billing contract.\n` +
+          `    ${who} must deposit ST tokens into the Billing contract before the processor can run.\n` +
+          `    Example (replace 100 with your desired ST amount):\n` +
           `    export AMOUNT=$(cast to-wei 100 ether)\n` +
-          `    cast send ${addresses.token} "approve(address,uint256)" ${addresses.billing} $AMOUNT --rpc-url ${networkConfig.rpcUrl} --private-key $PRIVATE_KEY\n` +
-          `    cast send ${addresses.billing} "deposit(uint256)" $AMOUNT --rpc-url ${networkConfig.rpcUrl} --private-key $PRIVATE_KEY`
+          `    cast send ${addresses.token} "approve(address,uint256)" ${addresses.billing} $AMOUNT --rpc-url ${networkConfig.rpcUrl} --private-key ${keyHint}\n` +
+          `    cast send ${addresses.billing} "deposit(uint256)" $AMOUNT --rpc-url ${networkConfig.rpcUrl} --private-key ${keyHint}`
       )
     )
   }


### PR DESCRIPTION
## Summary

In `--no-platform` mode, the existing `--owner` flag now means **on-chain owner address** (0x…) — `\$PRIVATE_KEY` becomes the operator key and signs `createProcessor`/`startProcessor`/`stopProcessor`/`deleteProcessor` on the owner's behalf. The contract layer is unchanged: `ProcessorRegistry.createProcessor(address owner, …)` overload + `isProcessorAdmin` (which already calls `Permissions.isOperator(owner, account)`) cover all four lifecycle ops.

- Pre-flight `Permissions.isOperator(owner, operator)` read; fails fast with a message pointing the user to `Permissions.addOperator` when missing.
- `checkSTBalance` / `checkBillingBalance` now query the **owner** in operator mode (operator only pays gas).
- Existing-processor compare uses the effective owner; replace flow (stop + delete + recreate) works for operators.
- Confirmation banner shows `Owner` / `Operator` rows separately when `--owner` is set; billing-deposit hint references `<owner's private key>` instead of `\$PRIVATE_KEY`.

Platform path (when `--no-platform` is **not** set) is untouched — `--owner` keeps its existing meaning of "project owner username".

## Test plan

End-to-end run on Sentio testnet (chain 7892101) with a freshly generated operator EOA:

- [x] Owner registers operator: `Permissions.addOperator(operator)` → `0x5b40f2f7…918fbf`
- [x] Operator-signed `createProcessor(owner, …)` → `0x3c546f64…1eaa5`; on-chain `getProcessor` returns owner = the configured `--owner`, not the operator
- [x] Operator-signed `startProcessor` → `0xb396b153…1c8355`
- [x] Operator-signed `stopProcessor` (via `sentio stop`) → `0x23d8beca…3e566`
- [x] Replace flow (re-running `sentio upload`): operator-signed `stopProcessor` + `deleteProcessor` + `createProcessor(owner, …)` + `startProcessor`
- [x] Pre-flight error path: passing an `--owner` that hasn't called `addOperator` exits cleanly
- [x] `pnpm tsc --noEmit` + `pnpm bundle` clean