### PR TITLE
chore(cli): point testnet config at redeployed contracts

### DIFF
--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -17,7 +17,7 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
   chainId: 7892101,
   rpcUrl: 'https://sentio-testnet.rpc.sentio.xyz',
   explorerUrl: 'https://testnet-explorer.sentio.xyz',
-  addressBookAddress: '0x11cDDF46f16925aa630Af9D5158028E56309868f'
+  addressBookAddress: '0x94579F0e7873097279B48d7b15043698c522e47c'
 }
 
 export function getSentioNetworkConfig(network: string): SentioNetworkConfig {


### PR DESCRIPTION
## Summary

- Bump `TESTNET_CONFIG.addressBookAddress` to the new AddressBook proxy `0x94579F0e7873097279B48d7b15043698c522e47c`, deployed today on Sentio testnet (chain 7892101).

The AddressBook resolves all 11 module addresses (IndexerRegistry, ProcessorRegistry, Controller, Staking, EpochController, VotingParameters, UsageTracker, Billing, Rewards, Permissions, Databases, plus SENTIO token), so this single address bump reloads the entire contract surface for SDK consumers.

## Test plan

- [ ] `pnpm install && pnpm -F @sentio/cli build` succeeds
- [ ] `pnpm sentio upload` against the new testnet resolves all module addresses correctly (`Resolving contract addresses from AddressBook...` followed by no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)