### PR TITLE
fix(cli): keep processor id stable for --no-platform uploads regardless of --owner

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -88,7 +88,14 @@ export function getAuthConfig(host: string): {
 }
 
 export function overrideConfigWithOptions(config: YamlProjectConfig, options: any) {
-  finalizeProjectName(config, options.owner, options.name)
+  // In `--no-platform` (Sentio Network) mode, `--owner` is a 0x-prefixed
+  // Ethereum address identifying the on-chain processor owner — completely
+  // orthogonal to the platform's "<username>/<slug>" project namespace.
+  // Don't let it rewrite `config.project`, since that field is the source
+  // of the on-chain processor id and a 42-char address would always
+  // overflow `ProcessorRegistry.MAX_PROCESSOR_ID_LENGTH` (32).
+  const projectOwner = options.platform === false ? undefined : options.owner
+  finalizeProjectName(config, projectOwner, options.name)
   finalizeHost(config, options.host)
 
   if (options.debug) {


### PR DESCRIPTION
## Summary

In \`--no-platform\` (Sentio Network) mode, \`--owner\` is a 0x-prefixed Ethereum address identifying the on-chain processor owner — entirely orthogonal to the platform's \`<username>/<slug>\` project namespace.

\`overrideConfigWithOptions\` was unconditionally feeding \`options.owner\` into \`finalizeProjectName\`, which rewrote \`config.project\` to \`<address 42 char>/<slug>\`. The downstream \`processorId = project.replace('/', '_')\` then always overflowed \`ProcessorRegistry.MAX_PROCESSOR_ID_LENGTH = 32\` and \`createProcessor\` reverted on-chain with \`execution reverted (unknown custom error)\`.

This PR gates the owner argument on \`options.platform !== false\` so the no-platform path keeps \`config.project\` at its YAML value. Example: \`project: myname/no-platform-test\` now always produces processor id \`myname_no-platform-test\` no matter who \`--owner\` points at.

## Test plan

Verified end-to-end against the Sentio testnet (chain 7892101):

- [x] yaml \`project: myname/no-platform-test\` + \`PRIVATE_KEY=<C>\` + \`--owner=<A>\` (after \`A.addOperator(C)\`) → on-chain processor id is \`myname_no-platform-test\`, \`getProcessorOwner == A\`, \`Databases.getPermission("<id>_0", A) == 5\` (Admin\|Read), \`getPermission("<id>_0", C) == 0\`, A's Billing balance pays for creation
- [x] yaml \`project: no-platform-test\` (no slash) + same flags → id \`no-platform-test\`, on-chain owner=A
- [x] Operator (\`C\`) signs \`Controller.stopProcessor\` and \`ProcessorRegistry.deleteProcessor\` to clean up; replica db cascade-cleared
- [x] Repro of pre-fix bug: same upload with current main reverts on \`createProcessor\` because the SDK builds a 59-char id (\`0xa1...A_no-platform-test\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)