### PR TITLE
feat(cli): add Sentio devnet support (chainID 7892201)

### DIFF
--- a/packages/cli/src/commands/stop-processor.ts
+++ b/packages/cli/src/commands/stop-processor.ts
@@ -16,7 +16,7 @@ export function createStopProcessorCommand() {
   return new Command('stop')
     .description('Stop a processor. Uses Sentio Network contract when --sentio-network is specified.')
     .argument('<processorId>', 'ID of the processor to stop')
-    .option('--sentio-network <network>', 'Stop via Sentio Network contract (only "testnet" supported)')
+    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet or devnet)')
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -85,14 +85,14 @@ export function createUploadCommand() {
     .option('--token <token>', '(Optional) Manually provide token rather than use saved credential')
     .option('--host <host>', '(Optional) Override Sentio Host name')
     .option('--num-workers <count>', '(Optional) Number of processor workers to start', myParseInt)
-    .option('--sentio-network <network>', '(Optional) Sentio network to connect to, can be testnet or mainnet')
+    .option('--sentio-network <network>', '(Optional) Sentio network to connect to, can be testnet, devnet or mainnet')
     .option(
       '--required-chain-id <chain_id...>',
       '(Optional) Specify chain IDs required for the Sentio network. This option is only available when --sentio-network is used. If omitted, all chain IDs from the project configuration (contracts or network overrides) will be used.'
     )
     .option(
       '--no-platform',
-      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Only testnet is supported.'
+      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Only testnet and devnet are supported.'
     )
     .option(
       '--ipfs-put-url <url>',
@@ -562,7 +562,7 @@ async function checkOrCreateProject(options: YamlProjectConfig, auth: Auth) {
     console.error(
       chalk.red(
         `Project ${project?.slug} is a Sentio Network project. Please add the --sentio-network flag when uploading.\n` +
-          `Example: sentio upload --sentio-network testnet`
+          `Example: sentio upload --sentio-network testnet|devnet`
       )
     )
     process.exit(1)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -115,12 +115,16 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
       case 'testnet':
         config.sentioNetwork = '7892101'
         break
+      case 'devnet':
+        config.sentioNetwork = '7892201'
+        break
       case '7892101':
+      case '7892201':
       case '789210':
         config.sentioNetwork = options.sentioNetwork
         break
       default:
-        console.error(`Invalid sentio network: ${options.sentioNetwork}, only mainnet or testnet is allowed`)
+        console.error(`Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet or devnet is allowed`)
         process.exit(1)
     }
   }

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -20,15 +20,26 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
   addressBookAddress: '0x94579F0e7873097279B48d7b15043698c522e47c'
 }
 
+const DEVNET_CONFIG: SentioNetworkConfig = {
+  chainId: 7892201,
+  rpcUrl: 'https://sentio-devnet.rpc.sentio.xyz',
+  explorerUrl: 'https://devnet-explorer.sentio.xyz',
+  // TODO: replace with actual AddressBook address once deployed on devnet
+  addressBookAddress: '0x0000000000000000000000000000000000000000'
+}
+
 export function getSentioNetworkConfig(network: string): SentioNetworkConfig {
   if (network === 'testnet' || network === '7892101') {
     return TESTNET_CONFIG
+  }
+  if (network === 'devnet' || network === '7892201') {
+    return DEVNET_CONFIG
   }
   if (network === 'mainnet' || network === '789210') {
     console.error(chalk.red('Sentio Network mainnet is not yet supported. Only testnet is available.'))
     process.exit(1)
   }
-  console.error(chalk.red(`Invalid sentio network: ${network}. Only "testnet" is supported.`))
+  console.error(chalk.red(`Invalid sentio network: ${network}. Only "testnet" or "devnet" is supported.`))
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary
- Add `DEVNET_CONFIG` in `network.ts` with RPC URL `https://sentio-devnet.rpc.sentio.xyz` and explorer `https://devnet-explorer.sentio.xyz`
- Support `devnet` / `7892201` as valid `--sentio-network` values in CLI commands
- Update help text in `upload`, `stop-processor` commands to mention devnet

## Notes
- AddressBook address on devnet is a placeholder (`0x000...`) pending contract deployment — update before devnet goes live

## Test plan
- [ ] `sentio upload --sentio-network devnet` routes to devnet config
- [ ] `sentio upload --sentio-network 7892201` routes to devnet config
- [ ] Invalid network still prints correct error message listing testnet and devnet
- [ ] Update `addressBookAddress` in `network.ts` once deployed on devnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)