### PR TITLE
fix(cli): point devnet config at deployed contracts

### DIFF
--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -22,10 +22,9 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
 
 const DEVNET_CONFIG: SentioNetworkConfig = {
   chainId: 7892201,
-  rpcUrl: 'https://sentio-devnet.rpc.sentio.xyz',
+  rpcUrl: 'https://sentio-devnet.test-rpc.sentio.xyz',
   explorerUrl: 'https://devnet-explorer.sentio.xyz',
-  // TODO: replace with actual AddressBook address once deployed on devnet
-  addressBookAddress: '0x0000000000000000000000000000000000000000'
+  addressBookAddress: '0xCfCE965429602b02b453477Cd8Bc7FEd5E8ffc14'
 }
 
 export function getSentioNetworkConfig(network: string): SentioNetworkConfig {


### PR DESCRIPTION
## Summary

- `DEVNET_CONFIG.addressBookAddress` was a placeholder `0x000…0`; replace with the deployed proxy `0xCfCE965429602b02b453477Cd8Bc7FEd5E8ffc14`.
- `DEVNET_CONFIG.rpcUrl` was `sentio-devnet.rpc.sentio.xyz` which doesn't resolve; the live endpoint is `sentio-devnet.test-rpc.sentio.xyz`.

## Test plan

- [x] Verified end-to-end on devnet (chain 7892201) with `yarn sentio upload --no-platform --sentio-network devnet --required-chain-id 1`:
  - AddressBook resolves all 11 contract addresses
  - `createProcessor` + `startProcessor` both mined
  - Processor allocated to indexer-b, `sentio_processorStatus` returns PROCESSING
  - `getProcessorOwner` and `Databases.getPermission(<pid>_0, owner) == 5` verified post-tx
- See full e2e walkthrough in [decentralization/e2e-devnet.md](https://github.com/sentioxyz/decentralization/blob/main/e2e-devnet.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)