### PR TITLE
feat(cli): add --sponsored upload path via Forwarder + ST billing

### DIFF
--- a/packages/cli/src/abi.ts
+++ b/packages/cli/src/abi.ts
@@ -134,7 +134,6 @@ export async function getABI(
     console.log('aptos module not loaded')
   }
 
-
   // ethereum
   try {
     const uploadAuth: Auth = {}
@@ -240,3 +239,23 @@ export function writeABIFile(obj: string | object, output: string) {
   fs.writeFileSync(output, data)
   console.log(chalk.green('ABI has been downloaded to', output))
 }
+
+export const FORWARDER_ABI = [
+  'function nonceOf(address user, uint192 key) view returns (uint64)',
+  'function hashForwardRequest((address from,address payer,address target,uint256 gas,uint192 nonceKey,uint64 nonceValue,uint48 deadline,uint256 maxFee,bytes data) req) view returns (bytes32)',
+  'function DOMAIN_SEPARATOR() view returns (bytes32)',
+  'function execute((address from,address payer,address target,uint256 gas,uint192 nonceKey,uint64 nonceValue,uint48 deadline,uint256 maxFee,bytes data) req, bytes sig) returns (bytes)',
+  'function executeBatch((address from,address payer,address target,uint256 gas,uint192 nonceKey,uint64 nonceValue,uint48 deadline,uint256 maxFee,bytes data)[] reqs, bytes[] sigs) returns (bytes[])',
+  'event ForwardExecuted(address indexed from, address indexed payer, address indexed target, bytes4 selector, uint192 nonceKey, uint64 nonceValue)',
+  'error Expired(uint48 deadline)',
+  'error BadNonce(uint192 key, uint64 expected, uint64 got)',
+  'error BadSig()',
+  'error NotIndexer(address relayer)',
+  'error LengthMismatch()'
+]
+
+export const RELAY_FEE_REGISTRY_ABI = ['function feeOf(address target, bytes4 selector) view returns (uint256)']
+
+export const INDEXER_REGISTRY_ABI = [
+  'function getFreshIndexers() view returns (tuple(uint256 id, bool active, address signer, string url, string name, uint16 computeNodeRpcPort, uint16 storageNodeRpcPort, uint16 clickhouseProxyPort, uint256 lastHeartbeatTimestamp, tuple(string chainId, bool enableRpc, bool enableTrace)[] supportedChains, uint256 commissionRate, uint256 exchangeRateSU, tuple(string[] skuIds, uint256[] skuUnitPrices) votingParams)[] freshIndexers)'
+]

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -99,6 +99,12 @@ export function createUploadCommand() {
       'IPFS upload endpoint (used with --no-platform)',
       'https://api.sentio.xyz/v1/ipfs/add'
     )
+    .option(
+      '--sponsored',
+      '(Optional, default true) Submit on-chain operations via Forwarder using ST billing balance',
+      true
+    )
+    .option('--no-sponsored', '(Optional) Bypass Forwarder; sign and pay native gas directly')
     .action(async (options, command) => {
       const processorConfig = loadProcessorConfig(options.path)
       overrideConfigWithOptions(processorConfig, options)
@@ -244,8 +250,8 @@ async function runNoPlatformUpload(
         process.exit(0)
       }
       // Stop and delete existing processor before re-creating
-      await stopProcessorOnChain(networkConfig, addresses, wallet, processorId)
-      await deleteProcessorOnChain(networkConfig, addresses, wallet, processorId)
+      await stopProcessorOnChain(networkConfig, addresses, wallet, processorId, ownerOverride, options.sponsored)
+      await deleteProcessorOnChain(networkConfig, addresses, wallet, processorId, ownerOverride, options.sponsored)
     } else {
       // Different owner — prompt to rename
       const expectedLabel = ownerOverride ? `expected owner ${ownerOverride}` : `your wallet ${wallet.address}`
@@ -287,11 +293,12 @@ async function runNoPlatformUpload(
     cid,
     requiredChainIds,
     sdkVersion,
-    ownerOverride
+    ownerOverride,
+    options.sponsored
   )
 
   // Step 9: Start processor on-chain
-  await startProcessorOnChain(networkConfig, addresses, wallet, processorId)
+  await startProcessorOnChain(networkConfig, addresses, wallet, processorId, ownerOverride, options.sponsored)
 
   console.log()
   console.log(chalk.green('=== Upload Complete ==='))

--- a/packages/cli/src/eip712.test.ts
+++ b/packages/cli/src/eip712.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ethers } from 'ethers'
+import { ForwardRequest, hashForwardRequest, signForwardRequest, FORWARDER_DOMAIN_TYPES } from './eip712.js'
+
+describe('eip712', () => {
+  it('hashForwardRequest matches on-chain hashTypedDataV4 byte-for-byte', () => {
+    const forwarderAddress = '0x0000000000000000000000000000000000000123'
+    const chainId = 7892101n
+    const req: ForwardRequest = {
+      from: '0x0000000000000000000000000000000000000001',
+      payer: '0x0000000000000000000000000000000000000001',
+      target: '0x0000000000000000000000000000000000000002',
+      gas: 200_000n,
+      nonceKey: 0n,
+      nonceValue: 0n,
+      deadline: 1_000_000n,
+      maxFee: 10_000_000_000_000n,
+      data: '0xdeadbeef'
+    }
+    const digest = hashForwardRequest(req, {
+      name: 'SentioForwarder',
+      version: '1',
+      chainId,
+      verifyingContract: forwarderAddress
+    })
+
+    // Cross-check via ethers.TypedDataEncoder.hash, which is the same algorithm
+    const domain = { name: 'SentioForwarder', version: '1', chainId, verifyingContract: forwarderAddress }
+    const expected = ethers.TypedDataEncoder.hash(domain, FORWARDER_DOMAIN_TYPES, req)
+    assert.equal(digest, expected)
+  })
+
+  it('signForwardRequest produces a 65-byte signature recoverable to the signer', async () => {
+    const wallet = ethers.Wallet.createRandom()
+    const req: ForwardRequest = {
+      from: wallet.address,
+      payer: wallet.address,
+      target: '0x0000000000000000000000000000000000000002',
+      gas: 200_000n,
+      nonceKey: 0n,
+      nonceValue: 0n,
+      deadline: 1_000_000n,
+      maxFee: 10_000_000_000_000n,
+      data: '0xdeadbeef'
+    }
+    const domain = {
+      name: 'SentioForwarder',
+      version: '1',
+      chainId: 7892101n,
+      verifyingContract: '0x0000000000000000000000000000000000000123'
+    }
+    const sig = await signForwardRequest(wallet, req, domain)
+    assert.equal(ethers.dataLength(sig), 65)
+    const recovered = ethers.verifyTypedData(domain, FORWARDER_DOMAIN_TYPES, req, sig)
+    assert.equal(recovered.toLowerCase(), wallet.address.toLowerCase())
+  })
+})

--- a/packages/cli/src/eip712.ts
+++ b/packages/cli/src/eip712.ts
@@ -1,0 +1,39 @@
+import { ethers, TypedDataDomain } from 'ethers'
+
+export interface ForwardRequest {
+  from: string
+  payer: string
+  target: string
+  gas: bigint
+  nonceKey: bigint
+  nonceValue: bigint
+  deadline: bigint
+  maxFee: bigint
+  data: string // 0x-prefixed hex
+}
+
+export const FORWARDER_DOMAIN_TYPES = {
+  ForwardRequest: [
+    { name: 'from', type: 'address' },
+    { name: 'payer', type: 'address' },
+    { name: 'target', type: 'address' },
+    { name: 'gas', type: 'uint256' },
+    { name: 'nonceKey', type: 'uint192' },
+    { name: 'nonceValue', type: 'uint64' },
+    { name: 'deadline', type: 'uint48' },
+    { name: 'maxFee', type: 'uint256' },
+    { name: 'data', type: 'bytes' }
+  ]
+}
+
+export function hashForwardRequest(req: ForwardRequest, domain: TypedDataDomain): string {
+  return ethers.TypedDataEncoder.hash(domain, FORWARDER_DOMAIN_TYPES, req)
+}
+
+export async function signForwardRequest(
+  signer: ethers.BaseWallet,
+  req: ForwardRequest,
+  domain: TypedDataDomain
+): Promise<string> {
+  return signer.signTypedData(domain, FORWARDER_DOMAIN_TYPES, req)
+}

--- a/packages/cli/src/indexer-rpc.test.ts
+++ b/packages/cli/src/indexer-rpc.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { callIndexerRpc } from './indexer-rpc.js'
+
+describe('indexerRpc', () => {
+  it('builds a valid JSON-RPC POST request', async () => {
+    let captured: any
+    const fakeFetch = async (url: string, init: any) => {
+      captured = { url, init }
+      return {
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: 'abc' })
+      } as unknown as Response
+    }
+    const result = await callIndexerRpc<string>(
+      'http://x:1',
+      'sentio_estimateRelayFee',
+      ['0xabc', '0x12345678'],
+      fakeFetch as any
+    )
+    assert.equal(result, 'abc')
+    assert.equal(captured.url, 'http://x:1')
+    const body = JSON.parse(captured.init.body)
+    assert.equal(body.method, 'sentio_estimateRelayFee')
+    assert.deepEqual(body.params, ['0xabc', '0x12345678'])
+  })
+
+  it('surfaces JSON-RPC error.message', async () => {
+    const fakeFetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: -32000, message: 'BillingBadNonce(expected=0, got=1)' }
+        })
+      }) as unknown as Response
+    await assert.rejects(
+      () => callIndexerRpc('http://x:1', 'sentio_submitForwardRequest', [], fakeFetch as any),
+      /BillingBadNonce/
+    )
+  })
+})

--- a/packages/cli/src/indexer-rpc.ts
+++ b/packages/cli/src/indexer-rpc.ts
@@ -1,0 +1,55 @@
+export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
+
+export async function callIndexerRpc<T>(
+  url: string,
+  method: string,
+  params: unknown[],
+  fetchFn: FetchFn = fetch
+): Promise<T> {
+  const res = await fetchFn(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })
+  })
+  if (!res.ok) {
+    throw new Error(`${method} HTTP ${res.status}`)
+  }
+  const json = (await res.json()) as { result?: T; error?: { code: number; message: string } }
+  if (json.error) {
+    throw new Error(`${method}: ${json.error.message}`)
+  }
+  return json.result as T
+}
+
+export interface ForwardRequestRpc {
+  from: string
+  payer: string
+  target: string
+  gas: string
+  nonceKey: string
+  nonceValue: number
+  deadline: number
+  maxFee: string
+  data: string
+  signature: string
+}
+
+export interface SubmitForwardResponse {
+  txHash: string
+  blockNumber: number
+  relayError?: { error: string; rawData: string }
+}
+
+export async function rpcEstimateRelayFee(url: string, target: string, selector: string): Promise<bigint> {
+  const raw = await callIndexerRpc<string>(url, 'sentio_estimateRelayFee', [target, selector])
+  return BigInt(raw)
+}
+
+export async function rpcGetRelayNonce(url: string, user: string, nonceKey: bigint): Promise<bigint> {
+  const raw = await callIndexerRpc<number>(url, 'sentio_getRelayNonce', [user, nonceKey.toString(10)])
+  return BigInt(raw)
+}
+
+export async function rpcSubmitForwardRequest(url: string, req: ForwardRequestRpc): Promise<SubmitForwardResponse> {
+  return callIndexerRpc<SubmitForwardResponse>(url, 'sentio_submitForwardRequest', [req])
+}

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import chalk from 'chalk'
 import fetch from 'node-fetch'
 import readline from 'readline'
+import { executeSponsored } from './sponsored.js'
 
 // --- Network Configuration ---
 
@@ -112,7 +113,10 @@ const ADDRESS_BOOK_KEYS = {
   token: 'sentio_token',
   billing: 'billing',
   databases: 'databases',
-  permissions: 'permissions'
+  permissions: 'permissions',
+  forwarder: 'forwarder',
+  relayFeeRegistry: 'relay_fee_registry',
+  indexerRegistry: 'indexer_registry'
 } as const
 
 interface ResolvedAddresses {
@@ -123,6 +127,9 @@ interface ResolvedAddresses {
   billing: string
   databases: string
   permissions: string
+  forwarder: string
+  relayFeeRegistry: string
+  indexerRegistry: string
 }
 
 let cachedAddresses: ResolvedAddresses | undefined
@@ -152,13 +159,26 @@ export async function resolveNetworkAddresses(config: SentioNetworkConfig): Prom
     }
   }
 
-  const [processorRegistry, controller, token, billing, databases, permissions] = await Promise.all([
+  const [
+    processorRegistry,
+    controller,
+    token,
+    billing,
+    databases,
+    permissions,
+    forwarder,
+    relayFeeRegistry,
+    indexerRegistry
+  ] = await Promise.all([
     resolveAddress(ADDRESS_BOOK_KEYS.processorRegistry),
     resolveAddress(ADDRESS_BOOK_KEYS.controller),
     resolveAddress(ADDRESS_BOOK_KEYS.token),
     resolveAddress(ADDRESS_BOOK_KEYS.billing),
     resolveAddress(ADDRESS_BOOK_KEYS.databases),
-    resolveAddress(ADDRESS_BOOK_KEYS.permissions)
+    resolveAddress(ADDRESS_BOOK_KEYS.permissions),
+    resolveAddress(ADDRESS_BOOK_KEYS.forwarder),
+    resolveAddress(ADDRESS_BOOK_KEYS.relayFeeRegistry),
+    resolveAddress(ADDRESS_BOOK_KEYS.indexerRegistry)
   ])
 
   console.log(chalk.gray(`ProcessorRegistry: ${processorRegistry}`))
@@ -167,6 +187,9 @@ export async function resolveNetworkAddresses(config: SentioNetworkConfig): Prom
   console.log(chalk.gray(`Billing:           ${billing}`))
   console.log(chalk.gray(`Databases:         ${databases}`))
   console.log(chalk.gray(`Permissions:       ${permissions}`))
+  console.log(chalk.gray(`Forwarder:         ${forwarder}`))
+  console.log(chalk.gray(`RelayFeeRegistry:  ${relayFeeRegistry}`))
+  console.log(chalk.gray(`IndexerRegistry:   ${indexerRegistry}`))
 
   cachedAddresses = {
     addressBook: addressBookAddr,
@@ -175,7 +198,10 @@ export async function resolveNetworkAddresses(config: SentioNetworkConfig): Prom
     token,
     billing,
     databases,
-    permissions
+    permissions,
+    forwarder,
+    relayFeeRegistry,
+    indexerRegistry
   }
   return cachedAddresses
 }
@@ -336,19 +362,44 @@ export async function deleteProcessorOnChain(
   config: SentioNetworkConfig,
   addresses: ResolvedAddresses,
   wallet: ethers.Wallet,
-  processorId: string
+  processorId: string,
+  ownerOverride?: string,
+  sponsored: boolean = true
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(config.rpcUrl)
-  const signer = wallet.connect(provider)
-
-  const registry = new ethers.Contract(addresses.processorRegistry, PROCESSOR_REGISTRY_ABI, signer)
 
   console.log(chalk.blue('Deleting existing processor on-chain...'))
-  const tx = await submitAndWait(config.explorerUrl, 'deleteProcessor', registry.deleteProcessor(processorId))
-  console.log(chalk.green(`Processor deleted. Tx: ${config.explorerUrl}/tx/${tx.hash}`))
+
+  let txHash: string
+  if (sponsored) {
+    const iface = new ethers.Interface(PROCESSOR_REGISTRY_ABI)
+    const data = iface.encodeFunctionData('deleteProcessor(string)', [processorId])
+    const { chainId } = await provider.getNetwork()
+    const resp = await executeSponsored({
+      wallet,
+      provider,
+      chainId,
+      forwarderAddress: addresses.forwarder,
+      relayFeeRegistryAddress: addresses.relayFeeRegistry,
+      indexerRegistryAddress: addresses.indexerRegistry,
+      target: addresses.processorRegistry,
+      data,
+      owner: ownerOverride,
+      nonceKey: 0n
+    })
+    txHash = resp.txHash
+    console.log(chalk.green(`Processor deleted. Tx: ${config.explorerUrl}/tx/${txHash}`))
+  } else {
+    const signer = wallet.connect(provider)
+    const registry = new ethers.Contract(addresses.processorRegistry, PROCESSOR_REGISTRY_ABI, signer)
+    const tx = await submitAndWait(config.explorerUrl, 'deleteProcessor', registry.deleteProcessor(processorId))
+    txHash = tx.hash
+    console.log(chalk.green(`Processor deleted. Tx: ${config.explorerUrl}/tx/${txHash}`))
+  }
+
   await waitForProcessorDatabaseCleanup(addresses, processorId, provider)
 
-  return tx.hash
+  return txHash
 }
 
 async function waitForProcessorDatabaseCleanup(
@@ -393,12 +444,10 @@ export async function createProcessorOnChain(
   ipfsCid: string,
   requiredChainIds: string[],
   sdkVersion: string,
-  ownerOverride?: string
+  ownerOverride?: string,
+  sponsored: boolean = true
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(config.rpcUrl)
-  const signer = wallet.connect(provider)
-
-  const registry = new ethers.Contract(addresses.processorRegistry, PROCESSOR_REGISTRY_ABI, signer)
 
   const source = {
     sourceType: 0, // IPFS
@@ -419,6 +468,43 @@ export async function createProcessorOnChain(
   if (ownerOverride) {
     console.log(chalk.gray(`  Owner:         ${ownerOverride} (operator: ${wallet.address})`))
   }
+
+  if (sponsored) {
+    const iface = new ethers.Interface(PROCESSOR_REGISTRY_ABI)
+    const data = ownerOverride
+      ? iface.encodeFunctionData('createProcessor(address,string,(uint8,string),(string,bool,bool)[],string)', [
+          ownerOverride,
+          processorId,
+          source,
+          requireChains,
+          sdkVersion
+        ])
+      : iface.encodeFunctionData('createProcessor(string,(uint8,string),(string,bool,bool)[],string)', [
+          processorId,
+          source,
+          requireChains,
+          sdkVersion
+        ])
+
+    const { chainId } = await provider.getNetwork()
+    const resp = await executeSponsored({
+      wallet,
+      provider,
+      chainId,
+      forwarderAddress: addresses.forwarder,
+      relayFeeRegistryAddress: addresses.relayFeeRegistry,
+      indexerRegistryAddress: addresses.indexerRegistry,
+      target: addresses.processorRegistry,
+      data,
+      owner: ownerOverride,
+      nonceKey: 0n
+    })
+    console.log(chalk.green(`Processor created. Tx: ${config.explorerUrl}/tx/${resp.txHash}`))
+    return resp.txHash
+  }
+
+  const signer = wallet.connect(provider)
+  const registry = new ethers.Contract(addresses.processorRegistry, PROCESSOR_REGISTRY_ABI, signer)
 
   // ethers v6 disambiguates overloads by full signature when both are present.
   const txPromise: Promise<ethers.TransactionResponse> = ownerOverride
@@ -444,14 +530,36 @@ export async function startProcessorOnChain(
   config: SentioNetworkConfig,
   addresses: ResolvedAddresses,
   wallet: ethers.Wallet,
-  processorId: string
+  processorId: string,
+  ownerOverride?: string,
+  sponsored: boolean = true
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(config.rpcUrl)
-  const signer = wallet.connect(provider)
-
-  const controller = new ethers.Contract(addresses.controller, CONTROLLER_ABI, signer)
 
   console.log(chalk.blue('Starting processor on-chain...'))
+
+  if (sponsored) {
+    const iface = new ethers.Interface(CONTROLLER_ABI)
+    const data = iface.encodeFunctionData('startProcessor(string)', [processorId])
+    const { chainId } = await provider.getNetwork()
+    const resp = await executeSponsored({
+      wallet,
+      provider,
+      chainId,
+      forwarderAddress: addresses.forwarder,
+      relayFeeRegistryAddress: addresses.relayFeeRegistry,
+      indexerRegistryAddress: addresses.indexerRegistry,
+      target: addresses.controller,
+      data,
+      owner: ownerOverride,
+      nonceKey: 0n
+    })
+    console.log(chalk.green(`Processor started. Tx: ${config.explorerUrl}/tx/${resp.txHash}`))
+    return resp.txHash
+  }
+
+  const signer = wallet.connect(provider)
+  const controller = new ethers.Contract(addresses.controller, CONTROLLER_ABI, signer)
   const tx = await submitAndWait(config.explorerUrl, 'startProcessor', controller.startProcessor(processorId))
   console.log(chalk.green(`Processor started. Tx: ${config.explorerUrl}/tx/${tx.hash}`))
   return tx.hash
@@ -461,21 +569,44 @@ export async function stopProcessorOnChain(
   config: SentioNetworkConfig,
   addresses: ResolvedAddresses,
   wallet: ethers.Wallet,
-  processorId: string
+  processorId: string,
+  ownerOverride?: string,
+  sponsored: boolean = true
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(config.rpcUrl)
-  const signer = wallet.connect(provider)
-
-  const controller = new ethers.Contract(addresses.controller, CONTROLLER_ABI, signer)
 
   // stopProcessor reverts with ProcessorNotAllocated if the processor has no active allocations
-  const allocations: unknown[] = await controller.getAllocations(processorId)
+  const controllerView = new ethers.Contract(addresses.controller, CONTROLLER_ABI, provider)
+  const allocations: unknown[] = await controllerView.getAllocations(processorId)
   if (allocations.length === 0) {
     console.log(chalk.gray('Processor has no allocations, skipping stopProcessor.'))
     return ''
   }
 
   console.log(chalk.blue('Stopping processor on-chain...'))
+
+  if (sponsored) {
+    const iface = new ethers.Interface(CONTROLLER_ABI)
+    const data = iface.encodeFunctionData('stopProcessor(string)', [processorId])
+    const { chainId } = await provider.getNetwork()
+    const resp = await executeSponsored({
+      wallet,
+      provider,
+      chainId,
+      forwarderAddress: addresses.forwarder,
+      relayFeeRegistryAddress: addresses.relayFeeRegistry,
+      indexerRegistryAddress: addresses.indexerRegistry,
+      target: addresses.controller,
+      data,
+      owner: ownerOverride,
+      nonceKey: 0n
+    })
+    console.log(chalk.green(`Processor stopped. Tx: ${config.explorerUrl}/tx/${resp.txHash}`))
+    return resp.txHash
+  }
+
+  const signer = wallet.connect(provider)
+  const controller = new ethers.Contract(addresses.controller, CONTROLLER_ABI, signer)
   const tx = await submitAndWait(config.explorerUrl, 'stopProcessor', controller.stopProcessor(processorId))
   console.log(chalk.green(`Processor stopped. Tx: ${config.explorerUrl}/tx/${tx.hash}`))
   return tx.hash

--- a/packages/cli/src/relayer.test.ts
+++ b/packages/cli/src/relayer.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { pickRelayerUrl, buildRelayerUrlList } from './relayer.js'
+
+describe('relayer', () => {
+  it('honors SENTIO_RELAYER_URL env override', async () => {
+    const original = process.env.SENTIO_RELAYER_URL
+    process.env.SENTIO_RELAYER_URL = 'http://localhost:8546'
+    try {
+      const url = await pickRelayerUrl({} as any, '0x0', () => Promise.resolve([]))
+      assert.equal(url, 'http://localhost:8546')
+    } finally {
+      if (original === undefined) delete process.env.SENTIO_RELAYER_URL
+      else process.env.SENTIO_RELAYER_URL = original
+    }
+  })
+
+  it('buildRelayerUrlList assembles scheme://url:port from Indexer struct', () => {
+    const indexers = [
+      { url: '64.38.144.158', storageNodeRpcPort: 10003n },
+      { url: '64.38.144.158', storageNodeRpcPort: 20003n },
+      { url: '103.67.203.149', storageNodeRpcPort: 10003n }
+    ]
+    const urls = buildRelayerUrlList(indexers as any, 'http')
+    assert.deepEqual(urls, ['http://64.38.144.158:10003', 'http://64.38.144.158:20003', 'http://103.67.203.149:10003'])
+  })
+
+  it('buildRelayerUrlList respects scheme env override', () => {
+    const indexers = [{ url: '64.38.144.158', storageNodeRpcPort: 10003n }]
+    const urls = buildRelayerUrlList(indexers as any, 'https')
+    assert.deepEqual(urls, ['https://64.38.144.158:10003'])
+  })
+})

--- a/packages/cli/src/relayer.ts
+++ b/packages/cli/src/relayer.ts
@@ -1,0 +1,67 @@
+import { ethers } from 'ethers'
+import { INDEXER_REGISTRY_ABI } from './abi.js'
+
+export interface FreshIndexer {
+  id: bigint
+  url: string
+  storageNodeRpcPort: bigint
+  // ...other fields exist but we don't need them
+}
+
+export function buildRelayerUrlList(indexers: FreshIndexer[], scheme: string): string[] {
+  return indexers.map((i) => `${scheme}://${i.url}:${i.storageNodeRpcPort}`)
+}
+
+/// Picks one relayer URL. Honors `SENTIO_RELAYER_URL` env override. Otherwise
+/// calls IndexerRegistry.getFreshIndexers() and picks one at random.
+export async function pickRelayerUrl(
+  provider: ethers.JsonRpcProvider,
+  indexerRegistryAddr: string,
+  freshFetcher?: () => Promise<FreshIndexer[]>
+): Promise<string> {
+  const override = process.env.SENTIO_RELAYER_URL
+  if (override) return override
+
+  const scheme = process.env.SENTIO_RELAYER_SCHEME ?? 'http'
+  const indexers = freshFetcher ? await freshFetcher() : await defaultFetch(provider, indexerRegistryAddr)
+  if (indexers.length === 0) {
+    throw new Error('no fresh indexers found via IndexerRegistry.getFreshIndexers()')
+  }
+  const urls = buildRelayerUrlList(indexers, scheme)
+  return urls[Math.floor(Math.random() * urls.length)]
+}
+
+/// Returns the full list of relayer URLs. Honors `SENTIO_RELAYER_URL` env override
+/// (returns `[override]` in that case). Otherwise calls IndexerRegistry.getFreshIndexers()
+/// and returns the shuffled list of `scheme://url:port` strings.
+export async function discoverRelayerUrls(
+  provider: ethers.JsonRpcProvider,
+  indexerRegistryAddr: string,
+  freshFetcher?: () => Promise<FreshIndexer[]>
+): Promise<string[]> {
+  const override = process.env.SENTIO_RELAYER_URL
+  if (override) return [override]
+
+  const scheme = process.env.SENTIO_RELAYER_SCHEME ?? 'http'
+  const indexers = freshFetcher ? await freshFetcher() : await defaultFetch(provider, indexerRegistryAddr)
+  if (indexers.length === 0) {
+    throw new Error('no fresh indexers found via IndexerRegistry.getFreshIndexers()')
+  }
+  const urls = buildRelayerUrlList(indexers, scheme)
+  // Shuffle in place so failover order is randomized across uploads.
+  for (let i = urls.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[urls[i], urls[j]] = [urls[j], urls[i]]
+  }
+  return urls
+}
+
+async function defaultFetch(provider: ethers.JsonRpcProvider, indexerRegistryAddr: string): Promise<FreshIndexer[]> {
+  const reg = new ethers.Contract(indexerRegistryAddr, INDEXER_REGISTRY_ABI, provider)
+  const raw = await reg.getFreshIndexers()
+  return raw.map((r: any) => ({
+    id: r.id,
+    url: r.url,
+    storageNodeRpcPort: r.storageNodeRpcPort
+  }))
+}

--- a/packages/cli/src/sponsored.test.ts
+++ b/packages/cli/src/sponsored.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ethers } from 'ethers'
+import { buildForwardRequest, tryRelayerWithFailover } from './sponsored.js'
+
+describe('sponsored helpers', () => {
+  it('buildForwardRequest sets payer=from when no owner passed', () => {
+    const wallet = ethers.Wallet.createRandom()
+    const req = buildForwardRequest({
+      signerAddress: wallet.address,
+      target: '0x0000000000000000000000000000000000000099',
+      data: '0xdeadbeef',
+      gas: 200_000n,
+      nonceKey: 0n,
+      nonceValue: 0n,
+      deadline: 1_000_000n,
+      maxFee: 12n
+    })
+    assert.equal(req.from, wallet.address)
+    assert.equal(req.payer, wallet.address)
+  })
+
+  it('buildForwardRequest sets payer=owner when owner provided', () => {
+    const wallet = ethers.Wallet.createRandom()
+    const owner = '0x0000000000000000000000000000000000000050'
+    const req = buildForwardRequest({
+      signerAddress: wallet.address,
+      owner,
+      target: '0x0000000000000000000000000000000000000099',
+      data: '0xdeadbeef',
+      gas: 200_000n,
+      nonceKey: 0n,
+      nonceValue: 0n,
+      deadline: 1_000_000n,
+      maxFee: 12n
+    })
+    assert.equal(req.from, wallet.address)
+    assert.equal(req.payer, owner)
+  })
+})
+
+describe('relayer failover', () => {
+  it('tries next URL on transport failure', async () => {
+    let calls = 0
+    const fn = async (url: string) => {
+      calls++
+      if (url.endsWith(':1')) throw new Error('ECONNREFUSED')
+      return { txHash: '0xok', blockNumber: 100 }
+    }
+    const result = await tryRelayerWithFailover(['http://a:1', 'http://b:2', 'http://c:3'], fn)
+    assert.equal(result.txHash, '0xok')
+    assert.equal(calls, 2)
+  })
+
+  it('throws after exhausting all URLs', async () => {
+    const fn = async () => {
+      throw new Error('boom')
+    }
+    await assert.rejects(() => tryRelayerWithFailover(['http://a:1', 'http://b:2'], fn), /failed to relay/)
+  })
+
+  it('does NOT failover when SENTIO_RELAYER_URL is set', async () => {
+    process.env.SENTIO_RELAYER_URL = 'http://locked'
+    try {
+      let calls = 0
+      const fn = async (_url: string) => {
+        calls++
+        throw new Error('boom')
+      }
+      await assert.rejects(() => tryRelayerWithFailover(['http://locked'], fn))
+      assert.equal(calls, 1) // only tried once
+    } finally {
+      delete process.env.SENTIO_RELAYER_URL
+    }
+  })
+})

--- a/packages/cli/src/sponsored.ts
+++ b/packages/cli/src/sponsored.ts
@@ -1,0 +1,130 @@
+import { ethers } from 'ethers'
+import chalk from 'chalk'
+import { ForwardRequest, signForwardRequest } from './eip712.js'
+import { discoverRelayerUrls } from './relayer.js'
+import { rpcSubmitForwardRequest, ForwardRequestRpc, SubmitForwardResponse } from './indexer-rpc.js'
+import { FORWARDER_ABI, RELAY_FEE_REGISTRY_ABI } from './abi.js'
+
+export interface BuildArgs {
+  signerAddress: string
+  owner?: string
+  target: string
+  data: string
+  gas: bigint
+  nonceKey: bigint
+  nonceValue: bigint
+  deadline: bigint
+  maxFee: bigint
+}
+
+export function buildForwardRequest(a: BuildArgs): ForwardRequest {
+  return {
+    from: a.signerAddress,
+    payer: a.owner ?? a.signerAddress,
+    target: a.target,
+    data: a.data,
+    gas: a.gas,
+    nonceKey: a.nonceKey,
+    nonceValue: a.nonceValue,
+    deadline: a.deadline,
+    maxFee: a.maxFee
+  }
+}
+
+export interface SponsoredCallOptions {
+  wallet: ethers.BaseWallet
+  provider: ethers.JsonRpcProvider
+  chainId: bigint
+  forwarderAddress: string
+  relayFeeRegistryAddress: string
+  indexerRegistryAddress: string
+  target: string
+  data: string
+  owner?: string
+  nonceKey?: bigint
+  maxFeeMultiplier?: number // default 1.2
+  gasLimit?: bigint // default 1_000_000
+  deadlineSeconds?: bigint // default now+600s
+}
+
+/// One-shot helper: discover, estimate, sign, submit, with failover.
+export async function executeSponsored(opts: SponsoredCallOptions): Promise<SubmitForwardResponse> {
+  const selectorHex = opts.data.slice(0, 10) // 0x + 8 hex chars
+  const nonceKey = opts.nonceKey ?? 0n
+  const gasLimit = opts.gasLimit ?? 1_000_000n
+  const multiplier = opts.maxFeeMultiplier ?? 1.2
+  const deadline = BigInt(Math.floor(Date.now() / 1000)) + (opts.deadlineSeconds ?? 600n)
+
+  // Read fee once — it doesn't depend on the relayer URL or nonce
+  const registry = new ethers.Contract(opts.relayFeeRegistryAddress, RELAY_FEE_REGISTRY_ABI, opts.provider)
+  const currentFee = (await registry.feeOf(opts.target, selectorHex)) as bigint
+  if (currentFee === 0n) {
+    throw new Error(`op not sponsored: target=${opts.target} selector=${selectorHex}`)
+  }
+  const maxFee = (currentFee * BigInt(Math.floor(multiplier * 1000))) / 1000n
+
+  const forwarder = new ethers.Contract(opts.forwarderAddress, FORWARDER_ABI, opts.provider)
+  const relayerUrls = await discoverRelayerUrls(opts.provider, opts.indexerRegistryAddress)
+
+  return tryRelayerWithFailover(relayerUrls, async (relayerUrl) => {
+    // Re-read nonce per attempt: a prior attempt may have raced with another
+    // tx submitted by the same user, or the user may have submitted self-pay
+    // ops between attempts.
+    const nonceValue = (await forwarder.nonceOf(opts.wallet.address, nonceKey)) as bigint
+    const req = buildForwardRequest({
+      signerAddress: opts.wallet.address,
+      owner: opts.owner,
+      target: opts.target,
+      data: opts.data,
+      gas: gasLimit,
+      nonceKey,
+      nonceValue,
+      deadline,
+      maxFee
+    })
+    const domain = {
+      name: 'SentioForwarder',
+      version: '1',
+      chainId: opts.chainId,
+      verifyingContract: opts.forwarderAddress
+    }
+    const signature = await signForwardRequest(opts.wallet, req, domain)
+    const rpcReq: ForwardRequestRpc = {
+      from: req.from,
+      payer: req.payer,
+      target: req.target,
+      gas: req.gas.toString(10),
+      nonceKey: req.nonceKey.toString(10),
+      nonceValue: Number(req.nonceValue),
+      deadline: Number(req.deadline),
+      maxFee: req.maxFee.toString(10),
+      data: req.data,
+      signature
+    }
+    console.log(chalk.gray(`  Sponsored relay → ${relayerUrl}`))
+    const resp = await rpcSubmitForwardRequest(relayerUrl, rpcReq)
+    if (resp.relayError) {
+      throw new Error(`relayer rejected: ${resp.relayError.error}`)
+    }
+    console.log(chalk.green(`  Tx mined in block ${resp.blockNumber}: ${resp.txHash}`))
+    return resp
+  })
+}
+
+/// Tries `fn` against each URL in order, returning the first successful result.
+/// When `SENTIO_RELAYER_URL` is set in the environment (explicit single-target mode)
+/// only the first URL is tried — failover is disabled. Otherwise up to 3 URLs
+/// are attempted before giving up.
+export async function tryRelayerWithFailover<T>(urls: string[], fn: (url: string) => Promise<T>): Promise<T> {
+  let lastErr: unknown
+  const explicit = process.env.SENTIO_RELAYER_URL != null
+  const maxAttempts = explicit ? 1 : Math.min(urls.length, 3)
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      return await fn(urls[i])
+    } catch (e) {
+      lastErr = e
+    }
+  }
+  throw new Error(`failed to relay after ${maxAttempts} attempt(s): ${(lastErr as Error)?.message}`)
+}


### PR DESCRIPTION
## Summary
- Adds a sponsored on-chain path to `sentio upload --no-platform`: SDK signs an EIP-712 `ForwardRequest` off-chain and submits via an indexer's storage-RPC, with the relay fee charged in ST from the user's billing balance. Defaults to `--sponsored=true`; `--no-sponsored` falls back to the existing self-pay path.
- Covers all 5 processor-lifecycle ops sponsored by the contracts: `createProcessor` (self + operator overloads), `deleteProcessor`, `startProcessor`, `stopProcessor`. Operator delegation: `--owner 0xA...` sets `payer = owner`, so A's billing pays while B signs.
- Backs [compute-network-contracts#62](https://github.com/sentioxyz/compute-network-contracts/pull/62) (merged) and [sentio-node#139](https://github.com/sentioxyz/sentio-node/pull/139).

## What's new

### `eip712.ts`
ForwardRequest typed-data definition + hash + sign helpers. The hash matches `ethers.TypedDataEncoder.hash` byte-for-byte, which itself matches the on-chain `Forwarder.hashForwardRequest` (cross-checked by the contract tests). Accepts `ethers.BaseWallet` (covers `Wallet` + `HDNodeWallet`).

### `relayer.ts`
Relayer URL discovery via on-chain `IndexerRegistry.getFreshIndexers()`. No hardcoded indexer list — URLs built from `${scheme}://${indexer.url}:${indexer.storageNodeRpcPort}` using fields already in the `Indexer` struct. `SENTIO_RELAYER_URL` env overrides for local-dev / pinning.

### `indexer-rpc.ts`
JSON-RPC client for the three new sentio-node methods. Surfaces the decoded `RelayError.error` string directly.

### `sponsored.ts`
`executeSponsored(opts)` orchestrator: discover URLs → read fee from chain → for each failover attempt, re-read nonce → build → sign → submit. Re-reading nonce per attempt avoids stale-nonce stalls when a concurrent tx bumped the user's Forwarder nonce. Max 3 attempts (or 1 if `SENTIO_RELAYER_URL` pins).

### `network.ts` + `commands/upload.ts`
Each `*OnChain` function gains `sponsored: boolean = true` (and `ownerOverride?: string` where missing). When sponsored, encodes calldata via `ethers.Interface` and calls `executeSponsored`. Self-pay path preserved verbatim. Upload command adds the paired commander boolean `--sponsored` / `--no-sponsored`.

## Tests
- `pnpm --filter "./packages/cli" build` clean
- `pnpm --filter "./packages/cli" exec glob -c 'tsx --test' 'src/**/*.test.ts'` — 12 new tests across eip712, relayer, indexer-rpc, sponsored (all green)
- The one pre-existing `abi.test.ts` failure (unrelated; depends on live API) is not from this branch.

## Test plan
- [x] Unit tests pass
- [x] Build clean
- [ ] End-to-end after testnet deploy + indexer canary: pre-fund a test EOA in billing, run `sentio upload --no-platform`, observe `Sponsored relay → http://<indexer>:<port>` + `Tx mined in block N`, verify billing decremented by 4 × 1e13 across the lifecycle
- [ ] Same with `--no-sponsored` to confirm self-pay path still works

## Dependencies
- Requires [compute-network-contracts#62](https://github.com/sentioxyz/compute-network-contracts/pull/62) merged (✅ as `fda98a2`).
- Requires [sentio-node#139](https://github.com/sentioxyz/sentio-node/pull/139) merged + at least one indexer running the new image so that `sentio_submitForwardRequest` is available.
- Requires Forwarder + RelayFeeRegistry deployed to testnet + AddressBook keys set + initial fees configured. Without the deploy, `--sponsored=true` will throw `op not sponsored` on the chain read.

## Rollout note
This change makes `--sponsored=true` the default. Users running `sentio upload --no-platform` against testnet **must** have ST in their billing balance before this version. They can `--no-sponsored` to opt out and self-pay native gas as before. Worth a release-notes callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)