### PR TITLE
fix(ci): disable pnpm 11 pre-command deps verification

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,6 @@
 engine-strict = true
 enable-pre-post-scripts=true
 shamefully-hoist = true
+# The publish-sdk workflow rewrites packages/{runtime,cli,sdk}/package.json
+# between install and publish to drop bundled deps from the npm artifact.
+verify-deps-before-run=false


### PR DESCRIPTION
## Summary

Fixes the failing [release run on commit 7782078](https://github.com/sentioxyz/sentio-sdk/actions/runs/26561202516/job/78244415056):

```
ERR_PNPM_OUTDATED_LOCKFILE: Cannot install with "frozen-lockfile"
because pnpm-lock.yaml is not up to date with packages/runtime/package.json
```

The publish-sdk workflow intentionally rewrites `packages/{runtime,cli,sdk}/package.json` between install and publish so bundled deps don't leak into the npm artifact. Under pnpm 10 this was silent; pnpm 11 added a pre-command deps verification that auto-runs `pnpm install` (with `frozen-lockfile=true` in CI) before commands like `publish`, and now catches the intentional drift.

Disable that auto-install via `verify-deps-before-run=false` in `.npmrc`, with an inline comment explaining why. The explicit `pnpm install` at the top of the workflow still runs normally and still enforces the lockfile — only the redundant pre-command auto-install is skipped.

## Test plan

- [ ] Merge and observe the next release run succeeds end-to-end (SDK publish + CLI publish + sdk-bundle + action steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)