### PR TITLE
fix(ci): move verify-deps-before-run=false to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-engine-strict = true
-enable-pre-post-scripts=true
-shamefully-hoist = true

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,3 @@
 engine-strict = true
 enable-pre-post-scripts=true
 shamefully-hoist = true
-# The publish-sdk workflow rewrites packages/{runtime,cli,sdk}/package.json
-# between install and publish to drop bundled deps from the npm artifact.
-verify-deps-before-run=false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,10 @@ shamefullyHoist: true
 # pnpm 11's default ~24h minimumReleaseAge blocks installing our own same-day
 # @typemove/* releases; disable it for this repo.
 minimumReleaseAge: 0
+# The publish-sdk workflow rewrites packages/{runtime,cli,sdk}/package.json
+# between install and publish to drop bundled deps from the npm artifact;
+# scripts/update-version.sh's `pnpm exec` would otherwise trip the post-11.3
+# deps verification (auto-install with frozen-lockfile) on that intentional drift.
+verifyDepsBeforeRun: false
 patchedDependencies:
   '@coral-xyz/anchor@0.31.1': patches/@coral-xyz__anchor@0.30.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,9 @@ allowBuilds:
   utf-8-validate: true
 # Keep hoisting so transitive deps (e.g. @fuel-ts/*, superstruct, ix, tslib) resolve.
 shamefullyHoist: true
+# Enforce engines field (was in .npmrc as `engine-strict=true`; pnpm 11 no longer
+# reads it from there).
+engineStrict: true
 # pnpm 11's default ~24h minimumReleaseAge blocks installing our own same-day
 # @typemove/* releases; disable it for this repo.
 minimumReleaseAge: 0


### PR DESCRIPTION
## Summary

Follow-up to #41, which set `verify-deps-before-run=false` in `.npmrc` but turned out to be silently ignored. The post-merge release run [still failed](https://github.com/sentioxyz/sentio-sdk/actions/runs/26563123887/job/78250838635) with the same `ERR_PNPM_OUTDATED_LOCKFILE`.

## Root cause (pinned down with a local repro)

1. **The trigger isn't `pnpm publish`** — `scripts/update-version.sh` runs `pnpm --filter "$FILTER" exec pnpm json …`, and **`pnpm exec`** is what calls `runDepsStatusCheck` in pnpm 11.3 (handler40 in `pnpm.mjs`). With `packages/runtime/package.json` already mutated by the "Clean runtime dependencies" step, the check finds the workspace state stale and runs an implicit `pnpm install --frozen-lockfile`, which fails on the drift.
2. **`.npmrc` is the wrong place for this setting in pnpm 11.** Confirmed: `pnpm config get verify-deps-before-run` returns `undefined` with the setting in `.npmrc`, and `false` only after moving it to `pnpm-workspace.yaml`. The repo's existing comment in `pnpm-workspace.yaml` already documents this:
   > pnpm 11 reads these from the workspace file (no longer from .npmrc / package.json "pnpm").

## Fix

- Move `verify-deps-before-run` to `pnpm-workspace.yaml` in camelCase (`verifyDepsBeforeRun: false`) where pnpm 11 actually reads it.
- While we're at it: clean up `.npmrc`. Empirically all three of its settings were dead under pnpm 11 (verified by diffing `pnpm config list --json` with and without the file):
  - `engine-strict = true` — silently ignored; migrated to `engineStrict: true` in `pnpm-workspace.yaml` to restore the original intent
  - `enable-pre-post-scripts=true` — silently ignored, and matches pnpm 11's built-in default; dropped
  - `shamefully-hoist = true` — duplicate of `shamefullyHoist: true` already in `pnpm-workspace.yaml`; dropped

## Verification

Reproduced and verified end-to-end locally:

```bash
# Mutate runtime/package.json the way the workflow does
(cd packages/runtime && pnpm json -I -f package.json -e 'this.dependencies={"piscina":"5.1.3"}')

# Before fix: fails with ERR_PNPM_OUTDATED_LOCKFILE inside update-version.sh
# After fix: succeeds
CI=true ./scripts/update-version.sh "@sentio/sdk..." 3.9.0-test
CI=true pnpm publish --filter "@sentio/sdk..." --no-git-checks --tag rc --dry-run
```

## Test plan

- [ ] Merge and observe the next release run succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)