### PR TITLE
chore(claude): fix CLAUDE.md staleness and add automation hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "enabledPlugins": {
+    "claude-md-management@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CHANGED=$(git status --porcelain 2>/dev/null | awk '{print $NF}'); if echo \"$CHANGED\" | grep -qE '(^|/)(package\\.json|pnpm-workspace\\.yaml|tsconfig\\.json)$|^scripts/|^\\.github/workflows/' && ! echo \"$CHANGED\" | grep -q '^CLAUDE\\.md$'; then printf '{\"systemMessage\":\"Project config files changed but CLAUDE.md was not updated. Consider running /claude-md-management:claude-md-improver to keep it current.\"}\\n'; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ sdk/src/tests/types/
 sdk/src/fuel/tests/types/
 
 **.generated
+
+# Personal Claude Code settings (project-shared config lives in .claude/settings.json)
+.claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,9 +182,10 @@ Tests require building the project first. Use `./scripts/test-all.sh` to build a
 
 ## Development Notes
 
-- **Node.js**: Requires Node.js 20+
-- **Package Manager**: Uses pnpm exclusively (enforced by preinstall script)
+- **Node.js**: Requires Node.js 24+ (`engines.node: ">=24"` in `package.json`; CI runs Node 24)
+- **Package Manager**: Uses pnpm exclusively, pinned via `packageManager: pnpm@11.3.0` (enforced by preinstall script)
 - **Monorepo**: Uses pnpm workspaces for dependency management
+- **`ethers` is patched**: The root `package.json` `resolutions` field redirects `ethers` to `@sentio/ethers` (a Sentio fork). Do not assume upstream `ethers` behavior — check the fork before relying on edge-case semantics.
 - **TypeScript**: Full TypeScript codebase with strict type checking
 - **ESLint**: Code quality enforcement with custom rules
 - **Git Hooks**: Automated formatting and linting on commit


### PR DESCRIPTION
## Summary
- **CLAUDE.md accuracy fix** — Node version was stale (doc said 20+, actual requirement is 24+ per `engines.node` and CI). Also documented the non-obvious `ethers` → `@sentio/ethers` `resolutions` override and the pinned pnpm version.
- **`.claude/settings.json` (new)** — declares `claude-md-management@claude-plugins-official` and `typescript-lsp@claude-plugins-official` as required project plugins, and adds a `Stop` hook that nudges contributors to run `/claude-md-management:claude-md-improver` whenever they touch `package.json` / `pnpm-workspace.yaml` / `tsconfig.json` / `scripts/` / `.github/workflows/` without also updating `CLAUDE.md`.
- **`.gitignore`** — excludes personal `.claude/settings.local.json` and the `.claude/worktrees/` scratch directory.

## Test plan
- [x] Hook command pipe-tested across 6 scenarios (config touched / config + CLAUDE.md touched / no config / scripts/ / nested package.json / empty changes) — all correct
- [x] `jq -e` validates the hook JSON shape in `.claude/settings.json`
- [x] `typescript-lsp` end-to-end verified with `documentSymbol` on `packages/cli/src/index.ts` (returned `program (Constant) - Line 26`)
- [x] `git check-ignore` confirms `.claude/settings.local.json` is excluded while `.claude/settings.json` is tracked
- [ ] Teammates: install `typescript-language-server typescript` globally to use the LSP plugin (`npm i -g typescript-language-server typescript`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)