### PR TITLE
chore(lint): clear remaining lint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig([
       '**/lib',
       '**/docs',
       '**/gen',
+      '**/generated',
       '**/types',
       '**/builtin',
       '**/templates',

--- a/packages/sdk/src/fuel/transaction.ts
+++ b/packages/sdk/src/fuel/transaction.ts
@@ -134,15 +134,15 @@ export async function decodeFuelTransactionWithAbi(
       console.warn('Failed to decode log', e)
     }
   })
-  const txResponse = new TransactionResponse(
-    gqlTransaction.status.transactionId,
+  const txResponse = new TransactionResponse({
+    transactionRequestOrId: gqlTransaction.status.transactionId,
     provider,
-    await provider.getChainId(),
-    {
+    chainId: await provider.getChainId(),
+    abis: {
       main: Object.values(abiMap)[0],
       otherContractsAbis: {}
     }
-  )
+  })
 
   // @ts-ignore - hack
   txResponse.gqlTransaction = {


### PR DESCRIPTION
## Summary

Two pre-existing lint warnings, unrelated to any specific feature but visible in every `pnpm lint` run:

- **`packages/sdk/src/fuel/transaction.ts:137`** — `TransactionResponse` positional-args constructor is deprecated in fuels. Switched to the object-style form: `new TransactionResponse({ transactionRequestOrId, provider, chainId, abis })`.
- **`packages/sdk/src/store/tests/generated/schema.ts`** — auto-generated file with `/* eslint-disable */` directive that's unused since the current generated content triggers no rules. Added `**/generated` to ESLint ignores (parallel to existing `**/gen`, `**/types`, `**/builtin`) so generated files are skipped entirely.

After this PR, `pnpm lint` exits clean.

## Test plan
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm --filter "@sentio/sdk" build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)