### PR TITLE
chore(fuel): upgrade fuels to 0.103.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -108,7 +108,7 @@
     "chalk": "^5.3.0",
     "csv-parse": "^6.0.0",
     "ethers": "npm:@sentio/ethers@6.13.1-patch.6",
-    "fuels": "^0.102.0",
+    "fuels": "^0.103.0",
     "got": "^14.4.7",
     "graphql": "^16.11.0",
     "js-sha3": "^0.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,8 +545,8 @@ importers:
         specifier: npm:@sentio/ethers@6.13.1-patch.6
         version: '@sentio/ethers@6.13.1-patch.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)'
       fuels:
-        specifier: ^0.102.0
-        version: 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+        specifier: ^0.103.0
+        version: 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       got:
         specifier: ^14.4.7
         version: 14.4.7
@@ -1359,71 +1359,71 @@ packages:
     resolution: {integrity: sha512-yZ0H5e3EpAYKokX/AbtplzlvSxEJY7ZfpvQyDzyODkks0hakAAlDG6fQu1SlDJMWorY7bbq1j7fCiFeTWci6TA==}
     hasBin: true
 
-  '@fuel-ts/abi-coder@0.102.0':
-    resolution: {integrity: sha512-eVbLGnDsGQXCwT4mA4xvasI6Jh+xEiSRbskAu8cUwSoVnaDBCUYH9EXFEOFBdM45hzXwh1+buhnigkF1cOZ5ZA==}
+  '@fuel-ts/abi-coder@0.103.0':
+    resolution: {integrity: sha512-tErLljHqz8Tnpndijd3XiGSbsBanFCeq2Bbl5DBjbVrZ737m5BqsYVYgBjSDkRmrRxz/uFFmXl1qLEU3MWNtPQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/abi-typegen@0.102.0':
-    resolution: {integrity: sha512-PkTsOluacxSLh4I/7+G0lia+hKYHvqe6eXx59Cvd3/91i16a/U8+owtqj2m5YUZtgb36tU1ewvTarVuFvZxbSA==}
+  '@fuel-ts/abi-typegen@0.103.0':
+    resolution: {integrity: sha512-XO9zai8MomXjCHnoa7K/gfO/Nco6Atmu8ptPJ1rHkhbftP75jXp5owflVFe+e+zvIXPA/UsZkM/uxJN0fB2njg==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
     hasBin: true
 
-  '@fuel-ts/account@0.102.0':
-    resolution: {integrity: sha512-VvoHV/5AsFAu+SZbR1d/+aE7dtSQ+qQuzHOexm3kk4dtTQA9v7RRl+2gA1GDJo01Zc5529mkXcZnb346+0odcw==}
+  '@fuel-ts/account@0.103.0':
+    resolution: {integrity: sha512-FI4iPK6yYtdU8d+pwknyVtOLAsxP0raybH3gPAWhYR7Bp4C4iA6dXnGXQcznBEW52Ez++5LjqvejJjZkIOzohw==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/address@0.102.0':
-    resolution: {integrity: sha512-//u/BpJSCLppnRv73c7fbJn7+m6cxOmq7BKyLyNrO66Fuq9NnKmgDrDtY4nErSBrYBdjPepvpLp5wzs9jVytEg==}
+  '@fuel-ts/address@0.103.0':
+    resolution: {integrity: sha512-Yb/mpU+4D4a6OdTLAvVeEFncNSLtW4NjToxdceDIv/y45TDFdubwcmMw+7gA/fDcn+6p88mojrcCEcRrnDg2qQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/contract@0.102.0':
-    resolution: {integrity: sha512-PUUiySGKb9usznxY99zl8S9X3L0XIlQKu1NzVVT9f0YXhwIqAkDvoCvCGgsPpF4RQAK7Q4KiJI0N/EGPL6PIXA==}
+  '@fuel-ts/contract@0.103.0':
+    resolution: {integrity: sha512-pdYxN7beDNn+JYRmQ1/1TYEK0QcWB4WvQsmAWlESE2WzmlMVDqoa4U1U5rsh5uZde1/Jb3TikXJeSWpyRa4J5Q==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/crypto@0.102.0':
-    resolution: {integrity: sha512-RFrca2bxG56j5WA9EwJYIeEzCfDH2nAU/g9rgEJr/wmMvSOH97QW3Nxym/o/bssdkEln++s51govXeBv8o+ztA==}
+  '@fuel-ts/crypto@0.103.0':
+    resolution: {integrity: sha512-8DWeYl1TkXY7Ga/2X1zI4Jv6Ua7mFHRgArwaSV0ckhk+Fu+KK4K9diUAge10TRUe11byG3cX2ObcVIlNtthnPg==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/errors@0.102.0':
-    resolution: {integrity: sha512-h/UXMnyY19G6UBOjiF2dXqv/pxPQW/EDbcGe9ELdOe8cXCItmnO8oTLtAvPHH4Z4IEK87CUpTW4+wD+MTj2Rqw==}
+  '@fuel-ts/errors@0.103.0':
+    resolution: {integrity: sha512-IvWB/Q7rRNYI/GrLuCD4EiGHOi5a+9a7P3AXMZ8gqE2PA5yYKUPQlI87xTvB9f9ZTiX1H/XwdCKprmKp6Nh16g==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/hasher@0.102.0':
-    resolution: {integrity: sha512-KkcdfSyzorNvKJKfrXBQjmJFuYVk1ABEwo3I0VtnWgNnDlHNmkmN8RzkPBnGmmPUWz+Nncf4PhlqjOhyamFa8Q==}
+  '@fuel-ts/hasher@0.103.0':
+    resolution: {integrity: sha512-P1EU4iHb7biGSqIldNEgkULcmrY11xdF9fE4Ja3EUZTViI1ekUt2a7r8402CkafLjBpheKzRpsdyL2pqkxJqdw==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/math@0.102.0':
-    resolution: {integrity: sha512-jo63N1b9+KHYUxWRS3ZPHkaxFmiiAyRUT6Xo8mVQ0LbtDxx0ulqexCBw1ITN5BYfarTOigF0I1GFgBLIVY6xSA==}
+  '@fuel-ts/math@0.103.0':
+    resolution: {integrity: sha512-djUGWHC45GN8xiI4r20eg3hs1pHcZzkNLLFoX3Mg4gcEyPesr0dt+TdvyFGr/tBqoEuS+IBAS2rFB6v1f3Q+Xg==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/merkle@0.102.0':
-    resolution: {integrity: sha512-pnNzU25GxE/3mUdTh0UC/KwrDp/paGAOwOaheTTGPftx7gHSgzrFfEnEzJf/i+y+eNK9fFOkav1gQ5dMkshqQg==}
+  '@fuel-ts/merkle@0.103.0':
+    resolution: {integrity: sha512-A80K7SZgOcnl0SuxurR+6bOAbKPM/gOMlcHDqeAU2vsClG2Zp3Apu1+v7PZJvPgi8JRUHDuDWlqpkNQvLRDvdQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/program@0.102.0':
-    resolution: {integrity: sha512-oR+Hj0kx8Z3TZoStRhik+q4+pNYHatTuasd50H1TAR/7H7Zs6ZNfs7cARVuqDhqvDNaV1ChYrjnkdDB65RHG8g==}
+  '@fuel-ts/program@0.103.0':
+    resolution: {integrity: sha512-GXvFpNsyg0VpDm8DXmpE+2oYSufprcPHciiwET1NpexlCGIdiPhBRDA3hqq6P+n+ovNNMNWHgwNxu77Yle9lxA==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/recipes@0.102.0':
-    resolution: {integrity: sha512-cq0ljg6QtByyCv7ntC56wc+x6GcKmwGAClEQRLRcj69WyZsy1uOlfZhLzWY3c4wa/TXgyyjijBN/XvMrCEavOg==}
+  '@fuel-ts/recipes@0.103.0':
+    resolution: {integrity: sha512-Ei3BTFQXM5Q+7PLln/ChdGis0oHJghdEjr7C8w/3dOGMcTVXwzQOg8kzNzXoYdDMgRxFBG6oX5Wi2JY+x8ShLg==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/script@0.102.0':
-    resolution: {integrity: sha512-WkDHcgEbrcsZk/1z+q+31Sx7JKuNtjVL09L4Rx7dLJMHoM1X5rlQdVvg6PZRFq3DUmHcZXjvG1p+/3nIu16UNA==}
+  '@fuel-ts/script@0.103.0':
+    resolution: {integrity: sha512-JN5fY5pNM/lnZlU6ZDKNExK0N5C/9I3/o8FbmZBh3i1pyNxDaceEbEX8YMu/PkWXlG5mbiDXYFNWRmzlV8rZ6g==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/transactions@0.102.0':
-    resolution: {integrity: sha512-UtWZPD6WvZud4Otmh9f7CwcAyvMARMprzUco8Qz7WT1dPXT6zflAqLtGx47BQG0nCt1LlrqpCUvDrRNq6WDadA==}
+  '@fuel-ts/transactions@0.103.0':
+    resolution: {integrity: sha512-oOZ/2Q1r+2823MDsMdD/pU3TwVmOfdaBjbudC+oCT+fidBZMAVRQfF/i4SWDtPfSsRuZRD0qDUA4zicYpxphiA==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
 
-  '@fuel-ts/utils@0.102.0':
-    resolution: {integrity: sha512-u6IJfo+SCEGZycnHxjHZFQpBKnO3xqyP6kMpVSl/uHa2IxKJl68QZmMXqjU8+JkXZ2uP+Ui56gZGoFeje0sPng==}
+  '@fuel-ts/utils@0.103.0':
+    resolution: {integrity: sha512-vYPb0vySLq0PZ0ytdWQnSeG1KjRBB90Fet114iS23sAd+Q1DZ75SHcgekPHkA0Hn4mTrE0Blch+d9tLnLeLrdw==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
     peerDependencies:
       vitest: 3.0.9
 
-  '@fuel-ts/versions@0.102.0':
-    resolution: {integrity: sha512-r71sNrg69uvnVyVsdivPQzlon3Aoa21tmPp8lFZ3PeVFpzh1NQ5H2tkUgFjvjX4WmbnSGeBvMjEd0WWWkY/Isw==}
+  '@fuel-ts/versions@0.103.0':
+    resolution: {integrity: sha512-+omgQvyrOY3e41CdeFBbYl3wWkAimLIKx4lwT+wWWH+/Hxqx5J6oy102ETlr7r93u25X2a68K+USZlR6v7JXMA==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
     hasBin: true
 
@@ -4584,8 +4584,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fuels@0.102.0:
-    resolution: {integrity: sha512-zDcSSnyPkxAqed8liHhRO7aQabQ4RY06hpSIbNl9A7F1go01Airn4FE47jc1zNGGO3nWQpf5G1pzOXNjnvVsKw==}
+  fuels@0.103.0:
+    resolution: {integrity: sha512-jV/EqE1/kibZzC1jqW4BhRyM7/ndX6+3W176crVs+260T48aa9rkNT1+TNqdmXewmjusqJ7La4GR1Cx7h/ZPcw==}
     engines: {node: ^20.0.0 || ^22.0.0 || ^24.0.0}
     hasBin: true
 
@@ -4665,6 +4665,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.1:
@@ -7951,22 +7952,22 @@ snapshots:
       graphql-import-node: 0.0.5(graphql@16.11.0)
       js-yaml: 4.1.0
 
-  '@fuel-ts/abi-coder@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/abi-coder@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/crypto': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/hasher': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       type-fest: 4.34.1
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/abi-typegen@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/abi-typegen@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/versions': 0.102.0
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/versions': 0.103.0
       commander: 13.1.0
       glob: 10.4.5
       handlebars: 4.7.8
@@ -7976,18 +7977,18 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/account@0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/account@0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/address': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/crypto': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/hasher': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/merkle': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/transactions': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/versions': 0.102.0
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/merkle': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/versions': 0.103.0
       '@fuels/vm-asm': 0.62.0
       '@noble/curves': 1.8.1
       events: 3.3.0
@@ -7999,128 +8000,128 @@ snapshots:
       - encoding
       - vitest
 
-  '@fuel-ts/address@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/address@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/crypto': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/contract@0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/contract@0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/account': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/crypto': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/hasher': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/merkle': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/program': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/transactions': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/account': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/merkle': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/program': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       '@fuels/vm-asm': 0.62.0
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/crypto@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/crypto@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/errors@0.102.0':
+  '@fuel-ts/errors@0.103.0':
     dependencies:
-      '@fuel-ts/versions': 0.102.0
+      '@fuel-ts/versions': 0.103.0
 
-  '@fuel-ts/hasher@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/hasher@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/crypto': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/math@0.102.0':
+  '@fuel-ts/math@0.103.0':
     dependencies:
-      '@fuel-ts/errors': 0.102.0
+      '@fuel-ts/errors': 0.103.0
       '@types/bn.js': 5.1.6
       bn.js: 5.2.1
 
-  '@fuel-ts/merkle@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/merkle@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/hasher': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/math': 0.102.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/math': 0.103.0
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/program@0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/program@0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/account': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/address': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/transactions': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/account': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
       '@fuels/vm-asm': 0.62.0
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/recipes@0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/recipes@0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/abi-typegen': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/account': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/address': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/contract': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/program': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/transactions': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-typegen': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/account': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/contract': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/program': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/script@0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/script@0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/account': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/program': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/transactions': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/account': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/program': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
     transitivePeerDependencies:
       - encoding
       - vitest
 
-  '@fuel-ts/transactions@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/transactions@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/address': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/hasher': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
     transitivePeerDependencies:
       - vitest
 
-  '@fuel-ts/utils@0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
+  '@fuel-ts/utils@0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))':
     dependencies:
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/versions': 0.102.0
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/versions': 0.103.0
       fflate: 0.8.2
       vitest: 3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1)
 
-  '@fuel-ts/versions@0.102.0':
+  '@fuel-ts/versions@0.103.0':
     dependencies:
       chalk: 4.1.2
       cli-table: 0.3.11
@@ -9454,7 +9455,7 @@ snapshots:
 
   '@solana/errors@2.3.0(typescript@5.9.2)':
     dependencies:
-      chalk: 5.6.0
+      chalk: 5.6.2
       commander: 14.0.3
       typescript: 5.9.2
 
@@ -10297,7 +10298,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11743,23 +11744,23 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fuels@0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1)):
+  fuels@0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1)):
     dependencies:
-      '@fuel-ts/abi-coder': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/abi-typegen': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/account': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/address': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/contract': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/crypto': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/errors': 0.102.0
-      '@fuel-ts/hasher': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/math': 0.102.0
-      '@fuel-ts/program': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/recipes': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/script': 0.102.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/transactions': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/utils': 0.102.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
-      '@fuel-ts/versions': 0.102.0
+      '@fuel-ts/abi-coder': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/abi-typegen': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/account': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/address': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/contract': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/crypto': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/program': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/recipes': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/script': 0.103.0(encoding@0.1.13)(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/transactions': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/utils': 0.103.0(vitest@3.0.9(@types/node@24.10.13)(tsx@4.15.7)(yaml@2.7.1))
+      '@fuel-ts/versions': 0.103.0
       '@fuels/vm-asm': 0.62.0
       bundle-require: 5.1.0(esbuild@0.25.3)
       chalk: 4.1.2


### PR DESCRIPTION
## Summary

Bumps \`fuels\` from \`^0.102.0\` to \`^0.103.0\` (latest stable). No source-code changes required.

## Test plan
- [x] \`pnpm --filter "@sentio/sdk" build\` — clean
- [x] Fuel tests (4 files: processor, transfer-processor, global-processor, typedprocessor) — 7 pass, 5 skipped, 0 fail
- [x] Full SDK test suite — 162 pass, 8 skipped, 0 fail
- [x] \`pnpm --filter "@sentio/sdk" build:bundle\` succeeds
- [x] CLI Fuel template \`processor.test.ts\` passes against the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)