### PR TITLE
chore(ts): TS6 follow-ups (eslint v10, drop glob, narrow catches)

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -737,8 +737,8 @@ export async function uploadFile(
     }
     try {
       await upload()
-    } catch (e) {
-      if (e.constructor.name === 'FetchError' && e.type === 'system' && e.code === 'EPIPE') {
+    } catch (e: any) {
+      if (e?.constructor.name === 'FetchError' && e.type === 'system' && e.code === 'EPIPE') {
         error = e
         await new Promise((resolve) => setTimeout(resolve, 1000))
         await tryUploading()

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -158,7 +158,9 @@ export async function resolveNetworkAddresses(config: SentioNetworkConfig): Prom
         const id = ethers.id(name)
         return await addressBook['getAddress(bytes32)'](id)
       } catch (e) {
-        throw new Error(`Failed to resolve "${name}" from AddressBook (${addressBookAddr}): ${e.message}`)
+        throw new Error(
+          `Failed to resolve "${name}" from AddressBook (${addressBookAddr}): ${e instanceof Error ? e.message : String(e)}`
+        )
       }
     }
   }

--- a/packages/runtime/src/full-service.ts
+++ b/packages/runtime/src/full-service.ts
@@ -319,7 +319,7 @@ export class FullProcessorServiceImpl implements ProcessorServiceImplementation 
         result.configUpdated = result.result?.states?.configUpdated
       }
       return result
-    } catch (e) {
+    } catch (e: any) {
       if (this.sdkVersion.minor <= 16) {
         // Old sdk doesn't handle this well
         if (

--- a/packages/runtime/src/provider.ts
+++ b/packages/runtime/src/provider.ts
@@ -169,7 +169,7 @@ export class QueuedStaticJsonRpcProvider extends JsonRpcProvider {
     let result
     try {
       result = await perform
-    } catch (e) {
+    } catch (e: any) {
       this.#performCache.delete(tag)
       if (e.code === 'TIMEOUT') {
         let retryCount = this.#retryCache.get(tag)

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -47,8 +47,11 @@ function mergeArrayInPlace<T>(dst: T[], src: T[]): T[] {
   return res
 }
 
-export function errorString(e: Error): string {
-  return e.message + '\n' + e.stack
+export function errorString(e: unknown): string {
+  if (e instanceof Error) {
+    return e.message + '\n' + e.stack
+  }
+  return String(e)
 }
 
 export const USER_PROCESSOR = 'user_processor'

--- a/packages/sdk/src/core/normalization.ts
+++ b/packages/sdk/src/core/normalization.ts
@@ -179,7 +179,9 @@ export function normalizeToRichStruct(...objs: any[]): RichStruct {
       try {
         ret.fields[key] = normalizeToRichValue(value)
       } catch (e) {
-        throw new Error("error when converting data for key '" + key + "': " + e.message)
+        throw new Error(
+          "error when converting data for key '" + key + "': " + (e instanceof Error ? e.message : String(e))
+        )
       }
     }
   }

--- a/packages/sdk/src/core/partition-handler-manager.ts
+++ b/packages/sdk/src/core/partition-handler-manager.ts
@@ -56,7 +56,10 @@ export class PartitionHandlerManager {
           }
         } catch (error) {
           // If partition handler fails, fall back to unrecognized
-          throw new ServerError(Status.INVALID_ARGUMENT, 'compute partition key failed, error:' + error.message)
+          throw new ServerError(
+            Status.INVALID_ARGUMENT,
+            'compute partition key failed, error:' + (error instanceof Error ? error.message : String(error))
+          )
         }
       } else {
         result[handlerId] = {

--- a/packages/sdk/src/eth/eth.ts
+++ b/packages/sdk/src/eth/eth.ts
@@ -60,21 +60,21 @@ export class SimpleEthersError extends Error {
   }
 }
 
-export function transformEtherError(e: Error, ctx: ContractContext<any, any> | undefined, stack?: string): Error {
+export function transformEtherError(e: unknown, ctx: ContractContext<any, any> | undefined, stack?: string): Error {
   if (e instanceof SimpleEthersError) {
     return e
   }
 
   const checkPage = 'Check here for possible cause and fix: https://docs.sentio.xyz/docs/handling-errors#ethers-error'
 
-  let msg = ''
   const err = e as CallExceptionError
-  if (err.code === 'CALL_EXCEPTION' || err.code === 'BAD_DATA') {
+  let msg = ''
+  if (err?.code === 'CALL_EXCEPTION' || err?.code === 'BAD_DATA') {
     if (err.data === '0x') {
       if (ctx) {
-        msg = `jsonrpc eth_call return '0x' (likely contract not existed) at chain ${ctx.chainId}, ${checkPage}:\n${e.message}`
+        msg = `jsonrpc eth_call return '0x' (likely contract not existed) at chain ${ctx.chainId}, ${checkPage}:\n${err.message}`
       } else {
-        msg = `jsonrpc eth_call return '0x' (likely contract not existed), ${checkPage}:\n${e.message}`
+        msg = `jsonrpc eth_call return '0x' (likely contract not existed), ${checkPage}:\n${err.message}`
       }
       return new SimpleEthersError(msg, err, stack)
     } else {
@@ -82,7 +82,8 @@ export function transformEtherError(e: Error, ctx: ContractContext<any, any> | u
     }
   }
 
-  msg = `other error during call error ${e.message}\n` + JSON.stringify(e) + '\n' + stack?.toString() + '\n' + checkPage
+  msg =
+    `other error during call error ${err?.message}\n` + JSON.stringify(e) + '\n' + stack?.toString() + '\n' + checkPage
   return new Error(msg)
 }
 

--- a/packages/sdk/src/eth/tests/error-capture.test.ts
+++ b/packages/sdk/src/eth/tests/error-capture.test.ts
@@ -42,7 +42,7 @@ describe('Test Error Capture', () => {
         })
       )
     } catch (e) {
-      err = e
+      err = e as Error
     }
     assert(err?.message.includes('Cannot record infinite value'))
   })
@@ -58,7 +58,7 @@ describe('Test Error Capture', () => {
         })
       )
     } catch (e) {
-      err = e
+      err = e as Error
     }
     assert(err?.message.includes('NaN'))
   })
@@ -73,7 +73,7 @@ describe('Test Error Capture', () => {
         })
       )
     } catch (e) {
-      err = e
+      err = e as Error
     }
     // should be convert to bigint if it's unsafe int
     assert(!err)

--- a/packages/sdk/src/store/decorators.ts
+++ b/packages/sdk/src/store/decorators.ts
@@ -25,7 +25,9 @@ function handleError(entity: string, key: string, fn: () => any) {
   try {
     return fn()
   } catch (e) {
-    throw new Error(`Get property "${key}" from Entity "${entity}" failed: ${e.message}`)
+    throw new Error(
+      `Get property "${key}" from Entity "${entity}" failed: ${e instanceof Error ? e.message : String(e)}`
+    )
   }
 }
 

--- a/packages/sdk/src/utils/call.ts
+++ b/packages/sdk/src/utils/call.ts
@@ -8,8 +8,8 @@ import { SimpleEthersError } from '../eth/index.js'
 export async function ignoreEthCallException<Res>(promise: Promise<Res>, logError = false): Promise<Res | undefined> {
   try {
     return await promise
-  } catch (err) {
-    if (err instanceof SimpleEthersError || err.code === 'CALL_EXCEPTION' || err.code === 'BAD_DATA') {
+  } catch (err: any) {
+    if (err instanceof SimpleEthersError || err?.code === 'CALL_EXCEPTION' || err?.code === 'BAD_DATA') {
       if (logError) {
         console.error('eth call exception, return undefined', err)
       }

--- a/packages/sdk/src/utils/dex-price.ts
+++ b/packages/sdk/src/utils/dex-price.ts
@@ -139,7 +139,7 @@ class DexPrice {
           ' at chain ' +
           this.chainId +
           '. Details: ' +
-          e.toString()
+          String(e)
       }
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
     "strictNullChecks": true,
     "strictFunctionTypes": false,
     "strictPropertyInitialization": false,
-    "useUnknownInCatchVariables": false,
     "stripInternal": true,
     "noFallthroughCasesInSwitch": true,
     "noEmitOnError": false,


### PR DESCRIPTION
Follow-ups after #47:

## Summary
- **CLI templates**: drop unneeded strict-flag pins from non-Move templates; only aptos/iota/sui keep \`strictFunctionTypes: false\`.
- **CLI test glob**: scope to \`src/**/*.test.ts\` only — \`**/*.test.ts\` was also picking up \`templates/*/src/processor.test.ts\` (user-facing samples, not cli tests).
- **Drop \`glob\` package**: \`tsx --test\` accepts glob patterns natively now; replaces \`glob -c 'tsx --test' '…'\` wrapper across cli/runtime/action/sdk and removes the \`glob\` devDep from root.
- **tsx**: bump \`^4.15.2\` → \`^4.22.3\`.
- **ESLint v10**: bump \`eslint\` 9.35 → 10.4, \`@eslint/js\` 9.35 → 10.0.1 and minor bumps for \`@eslint/compat\`, \`@eslint/eslintrc\`, \`eslint-import-resolver-typescript\`, \`eslint-plugin-import-x\`, \`eslint-plugin-unused-imports\`.
- **Drop \`useUnknownInCatchVariables: false\` override**: adopt TS6's default \`useUnknownInCatchVariables: true\` and fix the call sites instead of suppressing it. \`runtime/utils.errorString\` and \`sdk/eth.transformEtherError\` now accept \`unknown\` and narrow internally; other catch sites use \`e: any\` cast or \`e instanceof Error ? e.message : String(e)\`.

## Test plan
- [x] \`pnpm install\` clean
- [x] \`pnpm --filter "./packages/*" --filter "./examples/*" build\` green
- [x] \`pnpm --filter "./packages/cli/templates/**" build --skip-deps\` green
- [x] \`pnpm lint\` green (no eslint v10 warnings)
- [x] cli/runtime/action package tests green (\`tsx --test\` native glob works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)