### PR TITLE
chore(ts): drop strictFunctionTypes override; fix contravariant handler types

### DIFF
--- a/packages/cli/src/commands/alert.ts
+++ b/packages/cli/src/commands/alert.ts
@@ -360,14 +360,14 @@ async function injectProjectId(
   }
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
     .option('--owner <owner>', 'Sentio project owner')
@@ -375,17 +375,17 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+function withJsonInputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--file <path>', 'Read request JSON or YAML from file')
     .option('--stdin', 'Read request JSON or YAML from stdin')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function handleAlertCommandError(error: unknown, command?: Command) {
+function handleAlertCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -521,14 +521,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
     .option('--owner <owner>', 'Sentio project owner')
@@ -536,11 +536,11 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function handleDashboardCommandError(error: unknown, command?: Command) {
+function handleDashboardCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||

--- a/packages/cli/src/commands/data.ts
+++ b/packages/cli/src/commands/data.ts
@@ -566,14 +566,14 @@ async function runSqlExecutionRead(
   printOutput(options, data)
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
     .option('--owner <owner>', 'Sentio project owner')
@@ -581,19 +581,19 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+function withJsonInputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--file <path>', 'Read request JSON or YAML from file')
     .option('--stdin', 'Read request JSON or YAML from stdin')
 }
 
-function withQueryInputOptions<T extends Command<any, any, any>>(command: T) {
+function withQueryInputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--file <path>', 'Read request JSON or YAML from file. Use --doc to show the full insight query format')
     .option('--stdin', 'Read request JSON or YAML from stdin. Use --doc to show the full insight query format')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .showHelpAfterError()
     .option('--json', 'Print raw JSON response')
@@ -617,7 +617,7 @@ function printJson(data: unknown) {
   console.log(JSON.stringify(data, null, 2))
 }
 
-function handleDataCommandError(error: unknown, command?: Command) {
+function handleDataCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (error instanceof CliError && shouldShowHelpForDataCommandError(error)) {
     console.error(chalk.red(error.message))
     if (command) {

--- a/packages/cli/src/commands/endpoint.ts
+++ b/packages/cli/src/commands/endpoint.ts
@@ -366,14 +366,14 @@ async function runEndpointTest(options: EndpointTestOptions) {
   })
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <project>', 'Sentio project as <owner>/<slug> or <slug>')
     .option('--owner <owner>', 'Sentio project owner')
@@ -381,11 +381,11 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function handleEndpointCommandError(error: unknown, command?: Command) {
+function handleEndpointCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||

--- a/packages/cli/src/commands/price.ts
+++ b/packages/cli/src/commands/price.ts
@@ -185,24 +185,24 @@ async function runPriceCheckLatest(options: PriceOptions) {
   printOutput(options, unwrapApiResult(response))
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+function withJsonInputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--file <path>', 'Read request JSON or YAML from file')
     .option('--stdin', 'Read request JSON or YAML from stdin')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function handlePriceCommandError(error: unknown, command?: Command) {
+function handlePriceCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Provide exactly one coin identifier.') ||

--- a/packages/cli/src/commands/processor.ts
+++ b/packages/cli/src/commands/processor.ts
@@ -478,14 +478,14 @@ function colorSeverity(severity: string): string {
   }
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <owner/slug>', 'Sentio project in <owner>/<slug> format')
     .option('--owner <owner>', 'Sentio project owner')
@@ -493,11 +493,11 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function handleProcessorCommandError(error: unknown, command?: Command) {
+function handleProcessorCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -267,14 +267,14 @@ async function fetchProjectBySlug(options: ProjectLookupOptions, context: Return
   return fetchApiJson<{ project?: ProjectSummary }>(`/api/v1/project/${project.owner}/${project.slug}`, context)
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <owner/slug>', 'Sentio project in <owner>/<slug> format')
     .option('--owner <owner>', 'Sentio project owner')
@@ -282,11 +282,11 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function handleProjectCommandError(error: unknown, command?: Command) {
+function handleProjectCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||

--- a/packages/cli/src/commands/simulation.ts
+++ b/packages/cli/src/commands/simulation.ts
@@ -369,14 +369,14 @@ function buildTraceQuery(options: SimulationTraceOptions) {
   }
 }
 
-function withAuthOptions<T extends Command<any, any, any>>(command: T) {
+function withAuthOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')
 }
 
-function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) {
+function withSharedProjectOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--project <owner/slug>', 'Sentio project in <owner>/<slug> format')
     .option('--owner <owner>', 'Sentio project owner')
@@ -384,17 +384,17 @@ function withSharedProjectOptions<T extends Command<any, any, any>>(command: T) 
     .option('--project-id <id>', 'Sentio project id')
 }
 
-function withJsonInputOptions<T extends Command<any, any, any>>(command: T) {
+function withJsonInputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--file <path>', 'Read request JSON or YAML from file')
     .option('--stdin', 'Read request JSON or YAML from stdin')
 }
 
-function withOutputOptions<T extends Command<any, any, any>>(command: T) {
+function withOutputOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command.option('--json', 'Print raw JSON response').option('--yaml', 'Print raw YAML response')
 }
 
-function withTraceOptions<T extends Command<any, any, any>>(command: T) {
+function withTraceOptions<Args extends any[]>(command: Command<Args, any, any>) {
   return command
     .option('--chain-id <id>', 'Chain id')
     .option('--with-internal-calls', 'Fetch decoded trace with internal calls')
@@ -402,7 +402,7 @@ function withTraceOptions<T extends Command<any, any, any>>(command: T) {
     .option('--ignore-gas-cost', 'Ignore gas cost when optimizer is disabled')
 }
 
-function handleSimulationCommandError(error: unknown, command?: Command) {
+function handleSimulationCommandError(error: unknown, command?: Command<any[], any, any>) {
   if (
     error instanceof CliError &&
     (error.message.startsWith('Project is required.') ||

--- a/packages/runtime/src/logger.ts
+++ b/packages/runtime/src/logger.ts
@@ -52,9 +52,17 @@ export function setupLogger(json: boolean, enableDebug: boolean, workerId?: numb
     transports: [new transports.Console()]
   })
 
-  console.log = (...args: any[]) => logger.info.call(logger, ...args)
-  console.info = (...args: any[]) => logger.info.call(logger, ...args)
-  console.warn = (...args: any[]) => logger.warn.call(logger, ...args)
-  console.error = (...args: any[]) => logger.error.call(logger, ...args)
-  console.debug = (...args: any[]) => logger.debug.call(logger, ...args)
+  // Forward console output to winston, preserving `this` binding to the logger. The methods are
+  // typed through `(...args: any[]) => unknown` so the variadic args can be applied without tripping
+  // strict overload resolution on `Function.prototype.call`.
+  const forward =
+    (method: (...args: any[]) => unknown) =>
+    (...args: any[]) => {
+      method.apply(logger, args)
+    }
+  console.log = forward(logger.info)
+  console.info = forward(logger.info)
+  console.warn = forward(logger.warn)
+  console.error = forward(logger.error)
+  console.debug = forward(logger.debug)
 }

--- a/packages/sdk/src/aptos/aptos-processor.ts
+++ b/packages/sdk/src/aptos/aptos-processor.ts
@@ -78,10 +78,10 @@ export class AptosTransactionProcessor<T extends GeneralTransactionResponse, CT 
     return proxyProcessor(this)
   }
 
-  protected onMoveEvent(
-    handler: (event: Event, ctx: AptosContext) => PromiseOrVoid,
+  protected onMoveEvent<T extends Event = Event>(
+    handler: (event: T, ctx: AptosContext) => PromiseOrVoid,
     filter: EventFilter | EventFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, Event>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ): this {
     let _filters: EventFilter[] = []
     const _fetchConfig = MoveFetchConfig.fromPartial({ ...DEFAULT_FETCH_CONFIG, ...handlerOptions })
@@ -137,10 +137,10 @@ export class AptosTransactionProcessor<T extends GeneralTransactionResponse, CT 
     return this
   }
 
-  protected onEntryFunctionCall(
-    handler: (call: EntryFunctionPayloadResponse, ctx: AptosContext) => PromiseOrVoid,
+  protected onEntryFunctionCall<T extends EntryFunctionPayloadResponse = EntryFunctionPayloadResponse>(
+    handler: (call: T, ctx: AptosContext) => PromiseOrVoid,
     filter: FunctionNameAndCallFilter | FunctionNameAndCallFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, EntryFunctionPayloadResponse>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ): this {
     let _filters: FunctionNameAndCallFilter[] = []
     const _fetchConfig = MoveFetchConfig.fromPartial({ ...DEFAULT_FETCH_CONFIG, ...handlerOptions })
@@ -424,10 +424,10 @@ export class AptosModulesProcessor extends AptosTransactionProcessor<
     return new AptosModulesProcessor(options)
   }
 
-  public onMoveEvent(
-    handler: (event: Event, ctx: AptosContext) => PromiseOrVoid,
+  public onMoveEvent<T extends Event = Event>(
+    handler: (event: T, ctx: AptosContext) => PromiseOrVoid,
     filter: EventFilter | EventFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, Event>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ) {
     return super.onMoveEvent(handler, filter, handlerOptions)
   }

--- a/packages/sdk/src/eth/base-processor-template.ts
+++ b/packages/sdk/src/eth/base-processor-template.ts
@@ -62,7 +62,11 @@ export abstract class BaseProcessorTemplate<
 
   constructor() {
     this.id = ProcessorTemplateProcessorState.INSTANCE.getValues().length
-    ProcessorTemplateProcessorState.INSTANCE.addValue(this)
+    // Stored type-erased as the base instantiation; the concrete type parameters only appear in
+    // handler parameter positions, which `strictFunctionTypes` checks contravariantly.
+    ProcessorTemplateProcessorState.INSTANCE.addValue(
+      this as unknown as BaseProcessorTemplate<BaseContract, BoundContractView<BaseContract, any>>
+    )
     return proxyProcessor(this)
   }
 

--- a/packages/sdk/src/eth/base-processor.ts
+++ b/packages/sdk/src/eth/base-processor.ts
@@ -499,11 +499,11 @@ export abstract class BaseProcessor<
     return this.config.network
   }
 
-  public onEvent(
-    handler: (event: TypedEvent, ctx: ContractContext<TContract, TBoundContractView>) => PromiseOrVoid,
-    handlerOptions?: HandlerOptions<EthFetchConfig, TypedEvent>,
+  public onEvent<T extends TypedEvent = TypedEvent>(
+    handler: (event: T, ctx: ContractContext<TContract, TBoundContractView>) => PromiseOrVoid,
+    handlerOptions?: HandlerOptions<EthFetchConfig, T>,
     preprocessHandler: (
-      event: TypedEvent,
+      event: T,
       ctx: ContractContext<TContract, TBoundContractView>,
       preprocessStore: { [k: string]: any }
     ) => Promise<PreprocessResult> = defaultPreprocessHandler
@@ -520,12 +520,12 @@ export abstract class BaseProcessor<
     return this.onEthEvent(handler, _filters, handlerOptions, preprocessHandler)
   }
 
-  protected onEthEvent(
-    handler: (event: TypedEvent | RawEvent, ctx: ContractContext<TContract, TBoundContractView>) => PromiseOrVoid,
+  protected onEthEvent<T extends TypedEvent | RawEvent = TypedEvent | RawEvent>(
+    handler: (event: T, ctx: ContractContext<TContract, TBoundContractView>) => PromiseOrVoid,
     filter: DeferredTopicFilter | DeferredTopicFilter[],
-    handlerOptions?: HandlerOptions<EthFetchConfig, TypedEvent>,
+    handlerOptions?: HandlerOptions<EthFetchConfig, T>,
     preprocessHandler: (
-      event: TypedEvent,
+      event: T,
       ctx: ContractContext<TContract, TBoundContractView>,
       preprocessStore: { [k: string]: any }
     ) => Promise<PreprocessResult> = defaultPreprocessHandler,
@@ -593,7 +593,7 @@ export abstract class BaseProcessor<
         }
         if (parsed) {
           const event: TypedEvent = new TypedEvent(log, parsed.name, fixEmptyKey(parsed))
-          await handler(event, ctx)
+          await handler(event as T, ctx)
           return ctx.stopAndGetResult()
         }
         return ProcessResult.fromPartial({})
@@ -645,7 +645,7 @@ export abstract class BaseProcessor<
         }
         if (parsed) {
           const event: TypedEvent = new TypedEvent(log, parsed.name, fixEmptyKey(parsed))
-          return preprocessHandler(event, ctx, preprocessStore)
+          return preprocessHandler(event as T, ctx, preprocessStore)
         }
         return PreprocessResult.fromPartial({})
       },
@@ -663,7 +663,7 @@ export abstract class BaseProcessor<
           }
           if (parsed) {
             const event: TypedEvent = new TypedEvent(log, parsed.name, fixEmptyKey(parsed))
-            return p(event)
+            return p(event as T)
           }
           return undefined
         }

--- a/packages/sdk/src/fuel/fuel-processor-template.ts
+++ b/packages/sdk/src/fuel/fuel-processor-template.ts
@@ -41,7 +41,9 @@ export abstract class FuelBaseProcessorTemplate<TContract extends Contract> {
 
   constructor() {
     this.id = FuelProcessorTemplateProcessorState.INSTANCE.getValues().length
-    FuelProcessorTemplateProcessorState.INSTANCE.addValue(this)
+    // Stored type-erased as the base instantiation; the concrete type parameter only appears in
+    // handler parameter positions, which `strictFunctionTypes` checks contravariantly.
+    FuelProcessorTemplateProcessorState.INSTANCE.addValue(this as unknown as FuelBaseProcessorTemplate<Contract>)
     return proxyProcessor(this)
   }
 

--- a/packages/sdk/src/iota/iota-processor.ts
+++ b/packages/sdk/src/iota/iota-processor.ts
@@ -79,10 +79,10 @@ export class IotaBaseProcessor {
     return this.config.network
   }
 
-  protected onMoveEvent(
-    handler: (event: IotaEvent, ctx: IotaContext) => PromiseOrVoid,
+  protected onMoveEvent<T extends IotaEvent = IotaEvent>(
+    handler: (event: T, ctx: IotaContext) => PromiseOrVoid,
     filter: EventFilter | EventFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, IotaEvent>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ): IotaBaseProcessor {
     let _filters: EventFilter[] = []
     const _fetchConfig = MoveFetchConfig.fromPartial({ ...DEFAULT_FETCH_CONFIG, ...handlerOptions })
@@ -124,7 +124,7 @@ export class IotaBaseProcessor {
         )
 
         const decoded = await processor.coder.decodeEvent<any>(evt)
-        await handler(decoded || evt, ctx)
+        await handler((decoded || evt) as T, ctx)
 
         return ctx.stopAndGetResult()
       },
@@ -136,7 +136,7 @@ export class IotaBaseProcessor {
         if (typeof p === 'function') {
           const evt = JSON.parse(data.rawEvent) as IotaEvent
           const decoded = await processor.coder.decodeEvent<any>(evt)
-          return p(decoded || evt)
+          return p((decoded || evt) as T)
         }
         return p
       }
@@ -144,10 +144,10 @@ export class IotaBaseProcessor {
     return this
   }
 
-  protected onEntryFunctionCall(
-    handler: (call: MoveCallIotaTransaction, ctx: IotaContext) => PromiseOrVoid,
+  protected onEntryFunctionCall<T extends MoveCallIotaTransaction = MoveCallIotaTransaction>(
+    handler: (call: T, ctx: IotaContext) => PromiseOrVoid,
     filter: FunctionNameAndCallFilter | FunctionNameAndCallFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, MoveCallIotaTransaction>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ): IotaBaseProcessor {
     let _filters: FunctionNameAndCallFilter[] = []
     const _fetchConfig = MoveFetchConfig.fromPartial({ ...DEFAULT_FETCH_CONFIG, ...handlerOptions })
@@ -198,7 +198,7 @@ export class IotaBaseProcessor {
 
             // TODO maybe do in parallel
             const decoded = await processor.coder.decodeFunctionPayload(call, programmableTx?.inputs || [])
-            await handler(decoded, ctx)
+            await handler(decoded as T, ctx)
           }
         }
         return ctx.stopAndGetResult()
@@ -213,7 +213,7 @@ export class IotaBaseProcessor {
           const calls: MoveCallIotaTransaction[] = getMoveCalls(tx)
           // For simplicity, use the first call for partitioning
           if (calls.length > 0) {
-            return p(calls[0])
+            return p(calls[0] as T)
           }
           return undefined
         }

--- a/packages/sdk/src/solana/solana-processor.ts
+++ b/packages/sdk/src/solana/solana-processor.ts
@@ -18,7 +18,11 @@ export interface InstructionCoder {
   decode(ix: Buffer | string, encoding?: 'hex' | 'base58'): Instruction | null
 }
 
-export type SolanaInstructionHandler = (instruction: Instruction, ctx: SolanaContext, accounts?: string[]) => void
+export type SolanaInstructionHandler<T extends Instruction = Instruction> = (
+  instruction: T,
+  ctx: SolanaContext,
+  accounts: string[]
+) => void
 
 export interface InstructionHandlerEntry {
   handler: SolanaInstructionHandler
@@ -79,12 +83,12 @@ export class SolanaBaseProcessor {
     SolanaProcessorState.INSTANCE.addValue(this)
   }
 
-  public onInstruction(
+  public onInstruction<T extends Instruction = Instruction>(
     instructionName: string,
-    handler: SolanaInstructionHandler,
-    handlerOptions?: HandlerOptions<SolanaFetchConfig, Instruction>
+    handler: SolanaInstructionHandler<T>,
+    handlerOptions?: HandlerOptions<SolanaFetchConfig, T>
   ) {
-    this.instructionHandlerMap.set(instructionName, { handler, handlerOptions })
+    this.instructionHandlerMap.set(instructionName, { handler, handlerOptions } as InstructionHandlerEntry)
     return this
   }
 

--- a/packages/sdk/src/store/codegen.ts
+++ b/packages/sdk/src/store/codegen.ts
@@ -210,7 +210,7 @@ async function codegenInternal(schema: GraphQLSchema, source: string, target: st
               })
               fields.push({
                 name: f.name + 'ID' + (isMany ? 's' : ''),
-                type: isMany ? `Array<ID | undefined>` : `ID`,
+                type: isMany ? `Array<ID>` : `ID`,
                 annotations: []
               })
               if (isMany) {
@@ -317,7 +317,7 @@ export class ${c.name} ${c.parent ? `extends ${c.parent}` : ''} ${c.interfaces.l
 ${c.fields
   .map((f) => `${f.annotations.map((a) => `\n\t${a}`).join('')}\n\t${f.name}${f.optional ? '?' : ''}: ${f.type}`)
   .join('\n')}
-  ${isEntity ? `constructor(data: ${c.name}ConstructorInput) {super()}` : ''}
+  ${isEntity ? `constructor(data: Partial<${c.name}ConstructorInput>) {super()}` : ''}
   ${(c.methods ?? []).map(genMethod).join('\n')}
   
   ${

--- a/packages/sdk/src/store/store.ts
+++ b/packages/sdk/src/store/store.ts
@@ -96,7 +96,7 @@ export class Store {
       entity: [] as string[],
       id: [] as string[]
     }
-    const entityName = getEntityName(entity)
+    const entityName = getEntityName(entity as EntityClass<T> | T)
     if (id) {
       if (Array.isArray(id)) {
         for (const i of id) {

--- a/packages/sdk/src/sui/sui-processor.ts
+++ b/packages/sdk/src/sui/sui-processor.ts
@@ -76,10 +76,10 @@ export class SuiBaseProcessor {
     return this.config.network
   }
 
-  protected onMoveEvent(
-    handler: (event: SuiEventInput, ctx: SuiContext) => PromiseOrVoid,
+  protected onMoveEvent<T extends SuiEventInput = SuiEventInput>(
+    handler: (event: T, ctx: SuiContext) => PromiseOrVoid,
     filter: EventFilter | EventFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, SuiEventInput>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ): SuiBaseProcessor {
     let _filters: EventFilter[] = []
     const _fetchConfig = MoveFetchConfig.fromPartial({ ...DEFAULT_FETCH_CONFIG, ...handlerOptions })
@@ -118,8 +118,8 @@ export class SuiBaseProcessor {
           processor.config.baseLabels
         )
 
-        const decoded = await processor.coder.decodeEvent<any>(evt)
-        await handler(decoded || evt, ctx)
+        const decoded = await processor.coder.decodeEvent<T>(evt)
+        await handler((decoded || evt) as T, ctx)
 
         return ctx.stopAndGetResult()
       },
@@ -131,7 +131,7 @@ export class SuiBaseProcessor {
         if (typeof p === 'function') {
           const evt = JSON.parse(data.rawEvent) as SuiEventInput
           const decoded = await processor.coder.decodeEvent<any>(evt)
-          return p(decoded || evt)
+          return p((decoded || evt) as T)
         }
         return p
       }
@@ -139,10 +139,10 @@ export class SuiBaseProcessor {
     return this
   }
 
-  protected onEntryFunctionCall(
-    handler: (call: GrpcTypes.MoveCall, ctx: SuiContext) => PromiseOrVoid,
+  protected onEntryFunctionCall<T extends GrpcTypes.MoveCall = GrpcTypes.MoveCall>(
+    handler: (call: T, ctx: SuiContext) => PromiseOrVoid,
     filter: FunctionNameAndCallFilter | FunctionNameAndCallFilter[],
-    handlerOptions?: HandlerOptions<MoveFetchConfig, GrpcTypes.MoveCall>
+    handlerOptions?: HandlerOptions<MoveFetchConfig, T>
   ): SuiBaseProcessor {
     let _filters: FunctionNameAndCallFilter[] = []
     const _fetchConfig = MoveFetchConfig.fromPartial({ ...DEFAULT_FETCH_CONFIG, ...handlerOptions })
@@ -205,7 +205,7 @@ export class SuiBaseProcessor {
           const calls = getMoveCalls(tx)
           // For simplicity, use the first call for partitioning
           if (calls.length > 0) {
-            return p(calls[0])
+            return p(calls[0] as T)
           }
           return undefined
         }

--- a/packages/sdk/src/testing/memory-database.ts
+++ b/packages/sdk/src/testing/memory-database.ts
@@ -43,7 +43,10 @@ export class MemoryDatabase {
   }
 
   start() {
-    this.dbContext.subject.subscribe(this.processRequest.bind(this))
+    // The subject is typed `DeepPartial<ProcessStreamResponse>`, but at runtime it always carries a
+    // full response. Match the subscriber's parameter type and narrow inside (a bound method with the
+    // narrower `ProcessStreamResponse` parameter is rejected under `strictFunctionTypes`).
+    this.dbContext.subject.subscribe((request) => this.processRequest(request as ProcessStreamResponse))
   }
 
   stop() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "moduleResolution": "nodenext",
     "isolatedModules": true,
     "strictNullChecks": true,
-    "strictFunctionTypes": false,
     "strictPropertyInitialization": false,
     "stripInternal": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## What & why

The root `tsconfig.json` carried an explicit `strictFunctionTypes: false` opt-out. TypeScript 6.0 (this repo's version) defaults `strict` — and therefore `strictFunctionTypes`, `strictBindCallApply`, etc. — to `true`, and the repo never sets `strict`. So that line only suppressed a check that's otherwise on by default. This PR removes the opt-out and fixes everything it surfaces (~1670 errors).

Almost all errors come from one pattern: handler-registration callbacks typed for a **concrete** decoded event/call/instruction are passed into base methods that declare the **broad** base type. `strictFunctionTypes` checks function parameters contravariantly, so the narrower handler is rejected. Accepting it is sound — the framework always invokes these handlers with the concrete decoded value.

## Changes

### Chain processors — generic handler signatures
All chains use generic `<T extends Base>` handler-registration methods, with both `handler` and `handlerOptions` typed `T`:
- **aptos** `onMoveEvent` / `onEntryFunctionCall` (plus the public `onMoveEvent` override)
- **sui / iota** `onMoveEvent` / `onEntryFunctionCall`
- **eth** `onEvent` / `onEthEvent` (handler, handlerOptions and preprocessHandler)
- **solana** `onInstruction`; `SolanaInstructionHandler<T extends Instruction>` is generic with a required `accounts` parameter

Where the decoded value is typed (not `any`), the internal dispatch uses a targeted `as T` (sui/iota call + partitionKey paths, eth TypedEvent). aptos events decode via `decodeEvent<any>`, so no cast is needed there.

### store / EntityClass
`EntityClass<T>` keeps `new (data: Partial<T>): T`. Construct-signature params are contravariant under the flag too, so to keep that valid:
- store codegen now emits `constructor(data: Partial<XxxConstructorInput>)` — **incorporates #51** (@spacedragon)
- store codegen types `many`-relation `*IDs` fields as `Array<ID>` to match `ConstructorInput` (was `Array<ID | undefined>`)
- `Store.delete` narrows via `getEntityName(entity as EntityClass<T> | T)`

### CLI
- `with*Options` wrappers re-typed `<Args extends any[]>(command: Command<Args, any, any>)` so the positional-argument tuple is preserved and commander `.action()` handlers keep matching
- per-command `handleXCommandError` takes `Command<any[], any, any>`

### Misc
- eth/fuel generic processor templates: upcast `this` at self-registration
- `testing/memory-database`: match the subject's value type in `subscribe`
- `runtime/logger`: forward console output via `.apply` (drops the spread that tripped strict overload resolution)

## Verification
- `tsc --noEmit` clean across all packages
- full `build` of all packages **and** examples; CLI templates build
- `pnpm lint` clean
- tests: sdk 157✓, runtime 18✓, action 2✓ (the single `cli/abi.test.ts` failure is a pre-existing live block-explorer test, `todo`-skipped in CI)

## Notes
- Incorporates the codegen change from #51 (@spacedragon); if #51 lands independently the overlapping line is identical (no conflict).
- `*IDs` fields tighten from `Array<ID | undefined>` → `Array<ID>` — a codegen behavior change across all generated entities (more accurate; relation id lists shouldn't contain `undefined`, and the read side is safer).
- CLI scaffolding templates `packages/cli/templates/{sui,iota,aptos}/tsconfig.json` still set `strictFunctionTypes: false` (standalone configs, left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
