### PR TITLE
docs(agents): share Claude docs and skills

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Use AGENTS.md for Codex/Antigravity project docs, sharing content with CLAUDE.md
- Use .agents/skills for Codex/Antigravity project skills, symlinked to .claude/skills
- Keep CLAUDE.md and .claude/skills as the Claude-facing project paths
- Remove Gemini-specific project docs/skills from this setup

## Verification
- Commit/pre-push hooks passed where configured