### PR TITLE
release(major): begin v4

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - release
       - next
+      - develop/v3
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,10 +29,12 @@ jobs:
       - name: Set NPM variables
         id: npm
         run: |
-          BRANCH=${GITHUB_REF##*/}
+          BRANCH=${GITHUB_REF#refs/heads/}
           DIST_TAG=rc
           if [[ $BRANCH == "release" ]]; then
             DIST_TAG=latest
+          elif [[ $BRANCH == "develop/v3" ]]; then
+            DIST_TAG=rc3
           fi
           echo "dist_tag=${DIST_TAG}" >> $GITHUB_OUTPUT
 
@@ -125,7 +128,7 @@ jobs:
           ./scripts/update-version.sh @sentio/action ${{ steps.semantic.outputs.new_release_version }}
           pnpm publish --filter "@sentio/action" --no-git-checks --tag ${{ steps.npm.outputs.dist_tag }}
       - name: Clean Github Release for RC
-        if: ${{ contains(steps.semantic.outputs.new_release_version, '-rc.') == false }}
+        if: ${{ contains(steps.semantic.outputs.new_release_version, '-') == false }}
         run:  ./scripts/clean-rc-releases.sh
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/packages/action/release.config.cjs
+++ b/packages/action/release.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ["semantic-release-monorepo"],
-  branches: ['release', { name: 'main', prerelease: 'rc' }, { name: "next", prerelease: true }],
+  branches: ['release', { name: 'main', prerelease: 'rc' }, { name: "next", prerelease: true }, { name: 'develop/v3', prerelease: 'rc3' }],
   plugins: [
     [
       '@semantic-release/commit-analyzer',

--- a/packages/cli/release.config.cjs
+++ b/packages/cli/release.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ["semantic-release-monorepo"],
-  branches: ['release', { name: 'main', prerelease: 'rc' }, { name: "next", prerelease: true }],
+  branches: ['release', { name: 'main', prerelease: 'rc' }, { name: "next", prerelease: true }, { name: 'develop/v3', prerelease: 'rc3' }],
   plugins: [
     [
       '@semantic-release/commit-analyzer',

--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,6 @@
 export default {
   // extends: "semantic-release-monorepo",
-  branches: ['release', { name: 'main', prerelease: 'rc' }, { name: "next", prerelease: "rc-next" }],
+  branches: ['release', { name: 'main', prerelease: 'rc' }, { name: "next", prerelease: "rc-next" }, { name: 'develop/v3', prerelease: 'rc3' }],
   plugins: [
     [
       '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## Summary

Begin **Sentio SDK 4.0** development on `main`, and formalize the **v3** line on `develop/v3`.

- `main` → v4: this `release(major)` commit makes the next semantic-release run on `main` cut **`4.0.0-rc.1`** (npm dist-tag `rc`), per the existing `{ type: 'release', scope: 'major' }` rule. (Mirrors the historical `release(major): begin v3 branch` convention.)
- `develop/v3` → v3: forked at the **`v3.8.0`** release commit (`092e7d65`) and already pushed. It publishes prereleases on the **`rc3`** channel (npm dist-tag `rc3`).

## Changes

Adds `develop/v3` to the release topology so it stays consistent across branches (the same edits already live on `develop/v3`):

- `{ name: 'develop/v3', prerelease: 'rc3' }` added to the SDK (`release.config.js`), CLI, and action release configs.
- `publish-sdk.yaml`: trigger on `develop/v3`; publish it to npm dist-tag `rc3` (parse the full branch name — `${GITHUB_REF##*/}` alone yields `v3`).
- `publish-sdk.yaml`: gate the `Clean Github Release for RC` step on stable (no `-`) versions, so `-rc3` (and `-rc-next`) publishes don't delete every pre-release GitHub release.

## ⚠️ On merge

Merging this to `main` triggers the publish workflow and cuts **`4.0.0-rc.1`** to npm (`@sentio/sdk`, `@sentio/cli`, `@sentio/action`, `@sentio/sdk-bundle`) on dist-tag `rc`. Merge when you're ready for `main` to be v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)