### PR TITLE
feat(runtime): backport EthBlock/EthTrace raw_* with structpb fallback

### DIFF
--- a/packages/protos/processor.proto
+++ b/packages/protos/processor.proto
@@ -704,6 +704,7 @@ message Data {
   }
   message EthBlock {
     google.protobuf.Struct block = 2;
+    string raw_block = 1;
   }
   message EthTransaction {
     google.protobuf.Struct transaction = 4; // deprecated
@@ -722,6 +723,10 @@ message Data {
     optional google.protobuf.Struct transaction = 2;
     optional google.protobuf.Struct transaction_receipt = 3;
     optional google.protobuf.Struct block = 6;
+    string raw_trace = 7;
+    optional string raw_transaction = 8;
+    optional string raw_transaction_receipt = 9;
+    optional string raw_block = 10;
   }
   message SolInstruction {
     string instruction_data = 1;

--- a/packages/protos/src/processor/protos/processor.ts
+++ b/packages/protos/src/processor/protos/processor.ts
@@ -1239,6 +1239,7 @@ export interface Data_EthLog {
 
 export interface Data_EthBlock {
   block: { [key: string]: any } | undefined;
+  rawBlock: string;
 }
 
 export interface Data_EthTransaction {
@@ -1259,6 +1260,10 @@ export interface Data_EthTrace {
   transaction?: { [key: string]: any } | undefined;
   transactionReceipt?: { [key: string]: any } | undefined;
   block?: { [key: string]: any } | undefined;
+  rawTrace: string;
+  rawTransaction?: string | undefined;
+  rawTransactionReceipt?: string | undefined;
+  rawBlock?: string | undefined;
 }
 
 export interface Data_SolInstruction {
@@ -10068,13 +10073,16 @@ export const Data_EthLog = {
 };
 
 function createBaseData_EthBlock(): Data_EthBlock {
-  return { block: undefined };
+  return { block: undefined, rawBlock: "" };
 }
 
 export const Data_EthBlock = {
   encode(message: Data_EthBlock, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.block !== undefined) {
       Struct.encode(Struct.wrap(message.block), writer.uint32(18).fork()).ldelim();
+    }
+    if (message.rawBlock !== "") {
+      writer.uint32(10).string(message.rawBlock);
     }
     return writer;
   },
@@ -10093,6 +10101,13 @@ export const Data_EthBlock = {
 
           message.block = Struct.unwrap(Struct.decode(reader, reader.uint32()));
           continue;
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rawBlock = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -10103,13 +10118,19 @@ export const Data_EthBlock = {
   },
 
   fromJSON(object: any): Data_EthBlock {
-    return { block: isObject(object.block) ? object.block : undefined };
+    return {
+      block: isObject(object.block) ? object.block : undefined,
+      rawBlock: isSet(object.rawBlock) ? globalThis.String(object.rawBlock) : "",
+    };
   },
 
   toJSON(message: Data_EthBlock): unknown {
     const obj: any = {};
     if (message.block !== undefined) {
       obj.block = message.block;
+    }
+    if (message.rawBlock !== "") {
+      obj.rawBlock = message.rawBlock;
     }
     return obj;
   },
@@ -10120,6 +10141,7 @@ export const Data_EthBlock = {
   fromPartial(object: DeepPartial<Data_EthBlock>): Data_EthBlock {
     const message = createBaseData_EthBlock();
     message.block = object.block ?? undefined;
+    message.rawBlock = object.rawBlock ?? "";
     return message;
   },
 };
@@ -10322,6 +10344,10 @@ function createBaseData_EthTrace(): Data_EthTrace {
     transaction: undefined,
     transactionReceipt: undefined,
     block: undefined,
+    rawTrace: "",
+    rawTransaction: undefined,
+    rawTransactionReceipt: undefined,
+    rawBlock: undefined,
   };
 }
 
@@ -10341,6 +10367,18 @@ export const Data_EthTrace = {
     }
     if (message.block !== undefined) {
       Struct.encode(Struct.wrap(message.block), writer.uint32(50).fork()).ldelim();
+    }
+    if (message.rawTrace !== "") {
+      writer.uint32(58).string(message.rawTrace);
+    }
+    if (message.rawTransaction !== undefined) {
+      writer.uint32(66).string(message.rawTransaction);
+    }
+    if (message.rawTransactionReceipt !== undefined) {
+      writer.uint32(74).string(message.rawTransactionReceipt);
+    }
+    if (message.rawBlock !== undefined) {
+      writer.uint32(82).string(message.rawBlock);
     }
     return writer;
   },
@@ -10387,6 +10425,34 @@ export const Data_EthTrace = {
 
           message.block = Struct.unwrap(Struct.decode(reader, reader.uint32()));
           continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.rawTrace = reader.string();
+          continue;
+        case 8:
+          if (tag !== 66) {
+            break;
+          }
+
+          message.rawTransaction = reader.string();
+          continue;
+        case 9:
+          if (tag !== 74) {
+            break;
+          }
+
+          message.rawTransactionReceipt = reader.string();
+          continue;
+        case 10:
+          if (tag !== 82) {
+            break;
+          }
+
+          message.rawBlock = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -10403,6 +10469,12 @@ export const Data_EthTrace = {
       transaction: isObject(object.transaction) ? object.transaction : undefined,
       transactionReceipt: isObject(object.transactionReceipt) ? object.transactionReceipt : undefined,
       block: isObject(object.block) ? object.block : undefined,
+      rawTrace: isSet(object.rawTrace) ? globalThis.String(object.rawTrace) : "",
+      rawTransaction: isSet(object.rawTransaction) ? globalThis.String(object.rawTransaction) : undefined,
+      rawTransactionReceipt: isSet(object.rawTransactionReceipt)
+        ? globalThis.String(object.rawTransactionReceipt)
+        : undefined,
+      rawBlock: isSet(object.rawBlock) ? globalThis.String(object.rawBlock) : undefined,
     };
   },
 
@@ -10423,6 +10495,18 @@ export const Data_EthTrace = {
     if (message.block !== undefined) {
       obj.block = message.block;
     }
+    if (message.rawTrace !== "") {
+      obj.rawTrace = message.rawTrace;
+    }
+    if (message.rawTransaction !== undefined) {
+      obj.rawTransaction = message.rawTransaction;
+    }
+    if (message.rawTransactionReceipt !== undefined) {
+      obj.rawTransactionReceipt = message.rawTransactionReceipt;
+    }
+    if (message.rawBlock !== undefined) {
+      obj.rawBlock = message.rawBlock;
+    }
     return obj;
   },
 
@@ -10436,6 +10520,10 @@ export const Data_EthTrace = {
     message.transaction = object.transaction ?? undefined;
     message.transactionReceipt = object.transactionReceipt ?? undefined;
     message.block = object.block ?? undefined;
+    message.rawTrace = object.rawTrace ?? "";
+    message.rawTransaction = object.rawTransaction ?? undefined;
+    message.rawTransactionReceipt = object.rawTransactionReceipt ?? undefined;
+    message.rawBlock = object.rawBlock ?? undefined;
     return message;
   },
 };

--- a/packages/runtime/src/full-service.test.ts
+++ b/packages/runtime/src/full-service.test.ts
@@ -1,0 +1,91 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { RuntimeServicePatcher } from './full-service.js'
+import { DataBinding, HandlerType } from './gen/processor/protos/processor.js'
+
+// Verifies the back-compat path for the EthBlock/EthTrace structpb -> raw_*
+// migration: once a new driver stops sending the deprecated structpb `block` /
+// `trace` fields and only sends `raw_*`, the patcher must reconstruct the
+// structpb view from the raw JSON so existing handlers keep working.
+describe('RuntimeServicePatcher eth raw_* compatibility', () => {
+  const patcher = new RuntimeServicePatcher()
+
+  test('ETH_BLOCK: reconstructs structpb block from rawBlock', () => {
+    const block = { number: '0x1', hash: '0xabc' }
+    const binding: DataBinding = {
+      data: {
+        ethBlock: {
+          block: undefined,
+          rawBlock: JSON.stringify(block)
+        }
+      },
+      handlerType: HandlerType.ETH_BLOCK,
+      handlerIds: [0],
+      chainId: '1'
+    }
+    patcher.adjustDataBinding(binding)
+    assert.deepEqual(binding.data?.ethBlock?.block, block)
+  })
+
+  test('ETH_BLOCK: leaves an already-populated structpb block untouched', () => {
+    const block = { number: '0x2' }
+    const binding: DataBinding = {
+      data: {
+        ethBlock: {
+          block,
+          rawBlock: JSON.stringify({ number: '0xbad' })
+        }
+      },
+      handlerType: HandlerType.ETH_BLOCK,
+      handlerIds: [0],
+      chainId: '1'
+    }
+    patcher.adjustDataBinding(binding)
+    assert.deepEqual(binding.data?.ethBlock?.block, block)
+  })
+
+  test('ETH_TRACE: reconstructs trace and nested fields from raw_*', () => {
+    const trace = { type: 'call', action: { from: '0x1' } }
+    const transaction = { hash: '0xtx' }
+    const transactionReceipt = { status: '0x1' }
+    const block = { number: '0x5' }
+    const binding: DataBinding = {
+      data: {
+        ethTrace: {
+          trace: undefined,
+          timestamp: undefined,
+          rawTrace: JSON.stringify(trace),
+          rawTransaction: JSON.stringify(transaction),
+          rawTransactionReceipt: JSON.stringify(transactionReceipt),
+          rawBlock: JSON.stringify(block)
+        }
+      },
+      handlerType: HandlerType.ETH_TRACE,
+      handlerIds: [0],
+      chainId: '1'
+    }
+    patcher.adjustDataBinding(binding)
+    assert.deepEqual(binding.data?.ethTrace?.trace, trace)
+    assert.deepEqual(binding.data?.ethTrace?.transaction, transaction)
+    assert.deepEqual(binding.data?.ethTrace?.transactionReceipt, transactionReceipt)
+    assert.deepEqual(binding.data?.ethTrace?.block, block)
+  })
+
+  test('ETH_TRACE: leaves an already-populated structpb trace untouched', () => {
+    const trace = { type: 'call' }
+    const binding: DataBinding = {
+      data: {
+        ethTrace: {
+          trace,
+          timestamp: undefined,
+          rawTrace: JSON.stringify({ type: 'bad' })
+        }
+      },
+      handlerType: HandlerType.ETH_TRACE,
+      handlerIds: [0],
+      chainId: '1'
+    }
+    patcher.adjustDataBinding(binding)
+    assert.deepEqual(binding.data?.ethTrace?.trace, trace)
+  })
+})

--- a/packages/runtime/src/full-service.ts
+++ b/packages/runtime/src/full-service.ts
@@ -116,6 +116,28 @@ export class RuntimeServicePatcher {
           }
         }
         break
+      case HandlerType.ETH_BLOCK:
+        const ethBlock = dataBinding.data?.ethBlock
+        if (ethBlock?.block == null && ethBlock?.rawBlock) {
+          ethBlock.block = getParsedData(ethBlock.rawBlock)
+        }
+        break
+      case HandlerType.ETH_TRACE:
+        const ethTrace = dataBinding.data?.ethTrace
+        if (ethTrace?.trace == null && ethTrace?.rawTrace) {
+          ethTrace.trace = getParsedData(ethTrace.rawTrace)
+
+          if (ethTrace.rawTransaction) {
+            ethTrace.transaction = getParsedData(ethTrace.rawTransaction)
+          }
+          if (ethTrace.rawBlock) {
+            ethTrace.block = getParsedData(ethTrace.rawBlock)
+          }
+          if (ethTrace.rawTransactionReceipt) {
+            ethTrace.transactionReceipt = getParsedData(ethTrace.rawTransactionReceipt)
+          }
+        }
+        break
       case HandlerType.FUEL_TRANSACTION:
         if (compareSemver(this.sdkVersion, FUEL_PROTO_UPDATE_VERSION) < 0) {
           dataBinding.handlerType = HandlerType.FUEL_CALL

--- a/packages/runtime/src/gen/processor/protos/processor.ts
+++ b/packages/runtime/src/gen/processor/protos/processor.ts
@@ -1255,6 +1255,7 @@ export interface Data_EthLog {
 
 export interface Data_EthBlock {
   block: { [key: string]: any } | undefined;
+  rawBlock: string;
 }
 
 export interface Data_EthTransaction {
@@ -1275,6 +1276,10 @@ export interface Data_EthTrace {
   transaction?: { [key: string]: any } | undefined;
   transactionReceipt?: { [key: string]: any } | undefined;
   block?: { [key: string]: any } | undefined;
+  rawTrace: string;
+  rawTransaction?: string | undefined;
+  rawTransactionReceipt?: string | undefined;
+  rawBlock?: string | undefined;
 }
 
 export interface Data_SolInstruction {
@@ -10210,13 +10215,16 @@ export const Data_EthLog = {
 };
 
 function createBaseData_EthBlock(): Data_EthBlock {
-  return { block: undefined };
+  return { block: undefined, rawBlock: "" };
 }
 
 export const Data_EthBlock = {
   encode(message: Data_EthBlock, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.block !== undefined) {
       Struct.encode(Struct.wrap(message.block), writer.uint32(18).fork()).ldelim();
+    }
+    if (message.rawBlock !== "") {
+      writer.uint32(10).string(message.rawBlock);
     }
     return writer;
   },
@@ -10235,6 +10243,13 @@ export const Data_EthBlock = {
 
           message.block = Struct.unwrap(Struct.decode(reader, reader.uint32()));
           continue;
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rawBlock = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -10245,13 +10260,19 @@ export const Data_EthBlock = {
   },
 
   fromJSON(object: any): Data_EthBlock {
-    return { block: isObject(object.block) ? object.block : undefined };
+    return {
+      block: isObject(object.block) ? object.block : undefined,
+      rawBlock: isSet(object.rawBlock) ? globalThis.String(object.rawBlock) : "",
+    };
   },
 
   toJSON(message: Data_EthBlock): unknown {
     const obj: any = {};
     if (message.block !== undefined) {
       obj.block = message.block;
+    }
+    if (message.rawBlock !== "") {
+      obj.rawBlock = message.rawBlock;
     }
     return obj;
   },
@@ -10262,6 +10283,7 @@ export const Data_EthBlock = {
   fromPartial(object: DeepPartial<Data_EthBlock>): Data_EthBlock {
     const message = createBaseData_EthBlock();
     message.block = object.block ?? undefined;
+    message.rawBlock = object.rawBlock ?? "";
     return message;
   },
 };
@@ -10464,6 +10486,10 @@ function createBaseData_EthTrace(): Data_EthTrace {
     transaction: undefined,
     transactionReceipt: undefined,
     block: undefined,
+    rawTrace: "",
+    rawTransaction: undefined,
+    rawTransactionReceipt: undefined,
+    rawBlock: undefined,
   };
 }
 
@@ -10483,6 +10509,18 @@ export const Data_EthTrace = {
     }
     if (message.block !== undefined) {
       Struct.encode(Struct.wrap(message.block), writer.uint32(50).fork()).ldelim();
+    }
+    if (message.rawTrace !== "") {
+      writer.uint32(58).string(message.rawTrace);
+    }
+    if (message.rawTransaction !== undefined) {
+      writer.uint32(66).string(message.rawTransaction);
+    }
+    if (message.rawTransactionReceipt !== undefined) {
+      writer.uint32(74).string(message.rawTransactionReceipt);
+    }
+    if (message.rawBlock !== undefined) {
+      writer.uint32(82).string(message.rawBlock);
     }
     return writer;
   },
@@ -10529,6 +10567,34 @@ export const Data_EthTrace = {
 
           message.block = Struct.unwrap(Struct.decode(reader, reader.uint32()));
           continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.rawTrace = reader.string();
+          continue;
+        case 8:
+          if (tag !== 66) {
+            break;
+          }
+
+          message.rawTransaction = reader.string();
+          continue;
+        case 9:
+          if (tag !== 74) {
+            break;
+          }
+
+          message.rawTransactionReceipt = reader.string();
+          continue;
+        case 10:
+          if (tag !== 82) {
+            break;
+          }
+
+          message.rawBlock = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -10545,6 +10611,12 @@ export const Data_EthTrace = {
       transaction: isObject(object.transaction) ? object.transaction : undefined,
       transactionReceipt: isObject(object.transactionReceipt) ? object.transactionReceipt : undefined,
       block: isObject(object.block) ? object.block : undefined,
+      rawTrace: isSet(object.rawTrace) ? globalThis.String(object.rawTrace) : "",
+      rawTransaction: isSet(object.rawTransaction) ? globalThis.String(object.rawTransaction) : undefined,
+      rawTransactionReceipt: isSet(object.rawTransactionReceipt)
+        ? globalThis.String(object.rawTransactionReceipt)
+        : undefined,
+      rawBlock: isSet(object.rawBlock) ? globalThis.String(object.rawBlock) : undefined,
     };
   },
 
@@ -10565,6 +10637,18 @@ export const Data_EthTrace = {
     if (message.block !== undefined) {
       obj.block = message.block;
     }
+    if (message.rawTrace !== "") {
+      obj.rawTrace = message.rawTrace;
+    }
+    if (message.rawTransaction !== undefined) {
+      obj.rawTransaction = message.rawTransaction;
+    }
+    if (message.rawTransactionReceipt !== undefined) {
+      obj.rawTransactionReceipt = message.rawTransactionReceipt;
+    }
+    if (message.rawBlock !== undefined) {
+      obj.rawBlock = message.rawBlock;
+    }
     return obj;
   },
 
@@ -10578,6 +10662,10 @@ export const Data_EthTrace = {
     message.transaction = object.transaction ?? undefined;
     message.transactionReceipt = object.transactionReceipt ?? undefined;
     message.block = object.block ?? undefined;
+    message.rawTrace = object.rawTrace ?? "";
+    message.rawTransaction = object.rawTransaction ?? undefined;
+    message.rawTransactionReceipt = object.rawTransactionReceipt ?? undefined;
+    message.rawBlock = object.rawBlock ?? undefined;
     return message;
   },
 };

--- a/packages/runtime/src/seq-mode.test.ts
+++ b/packages/runtime/src/seq-mode.test.ts
@@ -40,7 +40,8 @@ describe('Test seq mode', () => {
           block: {
             number: '0x1',
             timestamp: '0x65ed3a46'
-          }
+          },
+          rawBlock: ''
         }
       },
       handlerType: HandlerType.ETH_BLOCK,
@@ -54,7 +55,8 @@ describe('Test seq mode', () => {
           block: {
             number: '0x2',
             timestamp: '0x65ed3b46'
-          }
+          },
+          rawBlock: ''
         }
       },
       handlerType: HandlerType.ETH_BLOCK,
@@ -69,7 +71,8 @@ describe('Test seq mode', () => {
           block: {
             number: '0x1',
             timestamp: '0x65ed3c46'
-          }
+          },
+          rawBlock: ''
         },
         chainId: '1'
       },

--- a/packages/sdk/src/eth/tests/erc20.test.ts
+++ b/packages/sdk/src/eth/tests/erc20.test.ts
@@ -106,7 +106,8 @@ describe('Test Basic Examples', () => {
               type: '0x0',
               cumulativeGasUsed: '0x8b56b3'
             },
-            timestamp: new Date()
+            timestamp: new Date(),
+            rawTrace: ''
           }
         },
         handlerIds: [handlerId],

--- a/packages/sdk/src/testing/eth-facet.ts
+++ b/packages/sdk/src/testing/eth-facet.ts
@@ -52,7 +52,8 @@ export class EthFacet {
             data: {
               ethTrace: {
                 trace,
-                timestamp: new Date()
+                timestamp: new Date(),
+                rawTrace: ''
               }
             },
             handlerIds: [config.handlerId],
@@ -232,7 +233,7 @@ export class EthFacet {
   ): DataBinding {
     const binding: DataBinding = {
       data: {
-        ethBlock: { block }
+        ethBlock: { block, rawBlock: '' }
       },
       handlerType: HandlerType.ETH_BLOCK,
       handlerIds: [],


### PR DESCRIPTION
## What

Backport the `EthBlock`/`EthTrace` structpb→`raw_*` migration to the **v3 maintenance line** so a v3 SDK runtime keeps working once the driver stops emitting the deprecated structpb `block`/`trace` fields and sends only `raw_*` JSON.

- **protos** — add `raw_block` to `Data.EthBlock` and `raw_trace` / `raw_transaction` / `raw_transaction_receipt` / `raw_block` to `Data.EthTrace`. Field definitions are taken verbatim from `sentio-core` `processor.proto`; the structpb fields are kept, so this is **purely additive** and safe across a rolling deploy.
- **runtime** — `RuntimeServicePatcher.adjustDataBinding` now handles `ETH_BLOCK` and `ETH_TRACE`: when the structpb view is absent it is reconstructed from the raw JSON (`block` from `rawBlock`; `trace` plus nested `transaction`/`transactionReceipt`/`block` from their `raw_*` counterparts), mirroring the existing `ETH_LOG` / `ETH_TRANSACTION` paths.
- **tests** — a new `full-service.test.ts` covers the `raw_*` → structpb reconstruction (and the "leave existing structpb untouched" case). Existing fixtures that build `EthBlock`/`EthTrace` literals now set the newly-required `rawBlock`/`rawTrace` (empty string).

## Why

Step 3 (v3) of the `EthBlock`/`EthTrace` structpb→`raw_*` migration:
1. `sentio-core` — add `raw_*` to the proto (additive). ✅ merged
2. drivers emit `raw_*` (raw-first).
3. **This PR** — v3 runtime reads `raw_*` with fallback to structpb.
4. driver release.
5. structpb fields removed (4.0 cleanup, on the v4 line).

After the driver release, a v3 processor receiving raw-only `EthBlock`/`EthTrace` data would otherwise see empty `block`/`trace`. This bridges that gap the same way `EthLog`/`EthTransaction` already do.

## Note on codegen

`head sentio-core`'s ts-proto toolchain has since moved to `@bufbuild/protobuf` (the v4 line), which v3 does not depend on. A full regen against it would migrate v3's entire proto runtime off `protobufjs`/`_m0` — out of scope for a compat backport. So the generated `processor.ts` (both `@sentio/protos` and the runtime gen copy) gained **only** the new fields, in v3's existing codegen style. The vendored `packages/protos/processor.proto` is byte-identical to `sentio-core` for these messages.

## Verification

- `@sentio/protos`, `@sentio/runtime`, `@sentio/sdk` — `tsc` / `tsc --noEmit` all green.
- Runtime tests (`seq-mode`, `service`, `service-v3`, new `full-service`) and SDK `erc20` eth tests pass.
- protobuf encode/decode round-trip confirmed for the new `rawBlock`/`rawTrace`/nested `raw_*` fields.
- prettier + eslint clean on changed sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
