### PR TITLE
feat(runtime): backport SolInstruction raw_parsed with structpb fallback

### DIFF
--- a/packages/protos/processor.proto
+++ b/packages/protos/processor.proto
@@ -730,7 +730,8 @@ message Data {
     uint64 slot = 2;
     string program_account_id = 3;
     repeated string accounts = 5;
-    optional google.protobuf.Struct parsed = 4;
+    optional google.protobuf.Struct parsed = 4; // deprecated
+    optional string raw_parsed = 7;
   }
   message AptEvent {
     string raw_event = 1;

--- a/packages/protos/src/processor/protos/processor.ts
+++ b/packages/protos/src/processor/protos/processor.ts
@@ -1263,6 +1263,7 @@ export interface Data_SolInstruction {
   programAccountId: string;
   accounts: string[];
   parsed?: { [key: string]: any } | undefined;
+  rawParsed?: string | undefined;
 }
 
 export interface Data_AptEvent {
@@ -10465,7 +10466,14 @@ export const Data_EthTrace = {
 };
 
 function createBaseData_SolInstruction(): Data_SolInstruction {
-  return { instructionData: "", slot: BigInt("0"), programAccountId: "", accounts: [], parsed: undefined };
+  return {
+    instructionData: "",
+    slot: BigInt("0"),
+    programAccountId: "",
+    accounts: [],
+    parsed: undefined,
+    rawParsed: undefined,
+  };
 }
 
 export const Data_SolInstruction = {
@@ -10487,6 +10495,9 @@ export const Data_SolInstruction = {
     }
     if (message.parsed !== undefined) {
       Struct.encode(Struct.wrap(message.parsed), writer.uint32(34).fork()).ldelim();
+    }
+    if (message.rawParsed !== undefined) {
+      writer.uint32(58).string(message.rawParsed);
     }
     return writer;
   },
@@ -10533,6 +10544,13 @@ export const Data_SolInstruction = {
 
           message.parsed = Struct.unwrap(Struct.decode(reader, reader.uint32()));
           continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.rawParsed = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -10549,6 +10567,7 @@ export const Data_SolInstruction = {
       programAccountId: isSet(object.programAccountId) ? globalThis.String(object.programAccountId) : "",
       accounts: globalThis.Array.isArray(object?.accounts) ? object.accounts.map((e: any) => globalThis.String(e)) : [],
       parsed: isObject(object.parsed) ? object.parsed : undefined,
+      rawParsed: isSet(object.rawParsed) ? globalThis.String(object.rawParsed) : undefined,
     };
   },
 
@@ -10569,6 +10588,9 @@ export const Data_SolInstruction = {
     if (message.parsed !== undefined) {
       obj.parsed = message.parsed;
     }
+    if (message.rawParsed !== undefined) {
+      obj.rawParsed = message.rawParsed;
+    }
     return obj;
   },
 
@@ -10582,6 +10604,7 @@ export const Data_SolInstruction = {
     message.programAccountId = object.programAccountId ?? "";
     message.accounts = object.accounts?.map((e) => e) || [];
     message.parsed = object.parsed ?? undefined;
+    message.rawParsed = object.rawParsed ?? undefined;
     return message;
   },
 };

--- a/packages/runtime/src/full-service.test.ts
+++ b/packages/runtime/src/full-service.test.ts
@@ -89,3 +89,53 @@ describe('RuntimeServicePatcher eth raw_* compatibility', () => {
     assert.deepEqual(binding.data?.ethTrace?.trace, trace)
   })
 })
+
+// Verifies the back-compat path for the SolInstruction structpb -> raw_parsed
+// migration: once a new driver stops sending the deprecated structpb `parsed`
+// field and only sends `raw_parsed`, the patcher must reconstruct the structpb
+// view from the raw JSON so existing instruction handlers keep working.
+describe('RuntimeServicePatcher solana raw_* compatibility', () => {
+  const patcher = new RuntimeServicePatcher()
+
+  test('SOL_INSTRUCTION: reconstructs parsed from rawParsed', () => {
+    const parsed = { type: 'transfer', info: { lamports: 1 } }
+    const binding: DataBinding = {
+      data: {
+        solInstruction: {
+          instructionData: '',
+          slot: BigInt(0),
+          programAccountId: 'prog',
+          accounts: [],
+          parsed: undefined,
+          rawParsed: JSON.stringify(parsed)
+        }
+      },
+      handlerType: HandlerType.SOL_INSTRUCTION,
+      handlerIds: [0],
+      chainId: 'sol-mainnet'
+    }
+    patcher.adjustDataBinding(binding)
+    assert.deepEqual(binding.data?.solInstruction?.parsed, parsed)
+  })
+
+  test('SOL_INSTRUCTION: leaves an already-populated parsed untouched', () => {
+    const parsed = { type: 'transfer' }
+    const binding: DataBinding = {
+      data: {
+        solInstruction: {
+          instructionData: '',
+          slot: BigInt(0),
+          programAccountId: 'prog',
+          accounts: [],
+          parsed,
+          rawParsed: JSON.stringify({ type: 'bad' })
+        }
+      },
+      handlerType: HandlerType.SOL_INSTRUCTION,
+      handlerIds: [0],
+      chainId: 'sol-mainnet'
+    }
+    patcher.adjustDataBinding(binding)
+    assert.deepEqual(binding.data?.solInstruction?.parsed, parsed)
+  })
+})

--- a/packages/runtime/src/full-service.ts
+++ b/packages/runtime/src/full-service.ts
@@ -158,6 +158,12 @@ export class RuntimeServicePatcher {
           }
         }
         break
+      case HandlerType.SOL_INSTRUCTION:
+        const solInstruction = dataBinding.data?.solInstruction
+        if (solInstruction?.parsed == null && solInstruction?.rawParsed) {
+          solInstruction.parsed = getParsedData(solInstruction.rawParsed)
+        }
+        break
       case HandlerType.FUEL_TRANSACTION:
         if (compareSemver(this.sdkVersion, FUEL_PROTO_UPDATE_VERSION) < 0) {
           dataBinding.handlerType = HandlerType.FUEL_CALL

--- a/packages/runtime/src/gen/processor/protos/processor.ts
+++ b/packages/runtime/src/gen/processor/protos/processor.ts
@@ -1277,6 +1277,7 @@ export interface Data_SolInstruction {
   programAccountId: string;
   accounts: string[];
   parsed?: { [key: string]: any } | undefined;
+  rawParsed?: string | undefined;
 }
 
 export interface Data_AptEvent {
@@ -10590,7 +10591,14 @@ export const Data_EthTrace = {
 };
 
 function createBaseData_SolInstruction(): Data_SolInstruction {
-  return { instructionData: "", slot: BigInt("0"), programAccountId: "", accounts: [], parsed: undefined };
+  return {
+    instructionData: "",
+    slot: BigInt("0"),
+    programAccountId: "",
+    accounts: [],
+    parsed: undefined,
+    rawParsed: undefined,
+  };
 }
 
 export const Data_SolInstruction = {
@@ -10612,6 +10620,9 @@ export const Data_SolInstruction = {
     }
     if (message.parsed !== undefined) {
       Struct.encode(Struct.wrap(message.parsed), writer.uint32(34).fork()).ldelim();
+    }
+    if (message.rawParsed !== undefined) {
+      writer.uint32(58).string(message.rawParsed);
     }
     return writer;
   },
@@ -10658,6 +10669,13 @@ export const Data_SolInstruction = {
 
           message.parsed = Struct.unwrap(Struct.decode(reader, reader.uint32()));
           continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.rawParsed = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -10674,6 +10692,7 @@ export const Data_SolInstruction = {
       programAccountId: isSet(object.programAccountId) ? globalThis.String(object.programAccountId) : "",
       accounts: globalThis.Array.isArray(object?.accounts) ? object.accounts.map((e: any) => globalThis.String(e)) : [],
       parsed: isObject(object.parsed) ? object.parsed : undefined,
+      rawParsed: isSet(object.rawParsed) ? globalThis.String(object.rawParsed) : undefined,
     };
   },
 
@@ -10694,6 +10713,9 @@ export const Data_SolInstruction = {
     if (message.parsed !== undefined) {
       obj.parsed = message.parsed;
     }
+    if (message.rawParsed !== undefined) {
+      obj.rawParsed = message.rawParsed;
+    }
     return obj;
   },
 
@@ -10707,6 +10729,7 @@ export const Data_SolInstruction = {
     message.programAccountId = object.programAccountId ?? "";
     message.accounts = object.accounts?.map((e) => e) || [];
     message.parsed = object.parsed ?? undefined;
+    message.rawParsed = object.rawParsed ?? undefined;
     return message;
   },
 };


### PR DESCRIPTION
## What

Backports the `SolInstruction` structpb→raw migration (sentio-core `feat(sol): add raw_parsed field to SolInstruction and deprecate parsed`) to the **v2** maintenance line, mirroring the EthBlock/EthTrace backport (#61) and the v3 Solana backport (#62).

Once a new driver stops emitting the deprecated structpb `parsed` field and sends only `raw_parsed` JSON, a v2 SDK runtime must reconstruct the structpb view so existing Solana instruction handlers keep working.

## Changes

- **protos** (`processor.proto` + both generated `processor.ts` copies): mark `Data.SolInstruction.parsed` deprecated and add `optional string raw_parsed = 7`. Field number **7** matches sentio-core and the v3 backport so the wire format is identical (v2's `SolInstruction` has no `raw_transaction`, but the field number is kept aligned, not reused as 6). The structpb field is kept, so this is additive and safe across a rolling deploy. The generated TS gained only the new field, preserving v2's ts-proto (`protobufjs`/`_m0`) codegen style.
- **runtime** (`full-service.ts`): `RuntimeServicePatcher.adjustDataBinding` now handles `SOL_INSTRUCTION` — when `parsed` is absent it is reconstructed from `raw_parsed`, mirroring the existing `ETH_*` paths.
- **tests**: new `full-service.test.ts` cases cover the `raw_parsed` → `parsed` reconstruction and the no-clobber case.

## Verification

- `tsc --noEmit` (runtime, after building `@sentio/protos`) and `@sentio/protos` build both pass.
- `full-service.test.ts`: 6/6 pass (incl. 2 new SOL cases).
- Wire + JSON round-trip of `raw_parsed` (field 7, tag 58) confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)