### PR TITLE
feat(solana)!: replace SolInstruction.parsed Struct with rawParsed string

### DIFF
--- a/packages/protos/processor.proto
+++ b/packages/protos/processor.proto
@@ -667,7 +667,7 @@ message Data {
     uint64 slot = 2;
     string program_account_id = 3;
     repeated string accounts = 5;
-    optional google.protobuf.Struct parsed = 4;
+    optional string raw_parsed = 7;
     optional string raw_transaction = 6;
   }
   message SolBlock {

--- a/packages/protos/src/processor/protos/processor.ts
+++ b/packages/protos/src/processor/protos/processor.ts
@@ -1185,7 +1185,7 @@ export interface Data_SolInstruction {
   slot: bigint;
   programAccountId: string;
   accounts: string[];
-  parsed?: { [key: string]: any } | undefined;
+  rawParsed?: string | undefined;
   rawTransaction?: string | undefined;
 }
 
@@ -10558,7 +10558,7 @@ function createBaseData_SolInstruction(): Data_SolInstruction {
     slot: 0n,
     programAccountId: "",
     accounts: [],
-    parsed: undefined,
+    rawParsed: undefined,
     rawTransaction: undefined,
   };
 }
@@ -10580,8 +10580,8 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
     for (const v of message.accounts) {
       writer.uint32(42).string(v!);
     }
-    if (message.parsed !== undefined) {
-      Struct.encode(Struct.wrap(message.parsed), writer.uint32(34).fork()).join();
+    if (message.rawParsed !== undefined) {
+      writer.uint32(58).string(message.rawParsed);
     }
     if (message.rawTransaction !== undefined) {
       writer.uint32(50).string(message.rawTransaction);
@@ -10628,12 +10628,12 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
           message.accounts.push(reader.string());
           continue;
         }
-        case 4: {
-          if (tag !== 34) {
+        case 7: {
+          if (tag !== 58) {
             break;
           }
 
-          message.parsed = Struct.unwrap(Struct.decode(reader, reader.uint32()));
+          message.rawParsed = reader.string();
           continue;
         }
         case 6: {
@@ -10667,7 +10667,11 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
         ? globalThis.String(object.program_account_id)
         : "",
       accounts: globalThis.Array.isArray(object?.accounts) ? object.accounts.map((e: any) => globalThis.String(e)) : [],
-      parsed: isObject(object.parsed) ? object.parsed : undefined,
+      rawParsed: isSet(object.rawParsed)
+        ? globalThis.String(object.rawParsed)
+        : isSet(object.raw_parsed)
+        ? globalThis.String(object.raw_parsed)
+        : undefined,
       rawTransaction: isSet(object.rawTransaction)
         ? globalThis.String(object.rawTransaction)
         : isSet(object.raw_transaction)
@@ -10690,8 +10694,8 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
     if (message.accounts?.length) {
       obj.accounts = message.accounts;
     }
-    if (message.parsed !== undefined) {
-      obj.parsed = message.parsed;
+    if (message.rawParsed !== undefined) {
+      obj.rawParsed = message.rawParsed;
     }
     if (message.rawTransaction !== undefined) {
       obj.rawTransaction = message.rawTransaction;
@@ -10708,7 +10712,7 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
     message.slot = object.slot ?? 0n;
     message.programAccountId = object.programAccountId ?? "";
     message.accounts = object.accounts?.map((e) => e) || [];
-    message.parsed = object.parsed ?? undefined;
+    message.rawParsed = object.rawParsed ?? undefined;
     message.rawTransaction = object.rawTransaction ?? undefined;
     return message;
   },

--- a/packages/runtime/src/gen/processor/protos/processor.ts
+++ b/packages/runtime/src/gen/processor/protos/processor.ts
@@ -1185,7 +1185,7 @@ export interface Data_SolInstruction {
   slot: bigint;
   programAccountId: string;
   accounts: string[];
-  parsed?: { [key: string]: any } | undefined;
+  rawParsed?: string | undefined;
   rawTransaction?: string | undefined;
 }
 
@@ -10558,7 +10558,7 @@ function createBaseData_SolInstruction(): Data_SolInstruction {
     slot: 0n,
     programAccountId: "",
     accounts: [],
-    parsed: undefined,
+    rawParsed: undefined,
     rawTransaction: undefined,
   };
 }
@@ -10580,8 +10580,8 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
     for (const v of message.accounts) {
       writer.uint32(42).string(v!);
     }
-    if (message.parsed !== undefined) {
-      Struct.encode(Struct.wrap(message.parsed), writer.uint32(34).fork()).join();
+    if (message.rawParsed !== undefined) {
+      writer.uint32(58).string(message.rawParsed);
     }
     if (message.rawTransaction !== undefined) {
       writer.uint32(50).string(message.rawTransaction);
@@ -10628,12 +10628,12 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
           message.accounts.push(reader.string());
           continue;
         }
-        case 4: {
-          if (tag !== 34) {
+        case 7: {
+          if (tag !== 58) {
             break;
           }
 
-          message.parsed = Struct.unwrap(Struct.decode(reader, reader.uint32()));
+          message.rawParsed = reader.string();
           continue;
         }
         case 6: {
@@ -10667,7 +10667,11 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
         ? globalThis.String(object.program_account_id)
         : "",
       accounts: globalThis.Array.isArray(object?.accounts) ? object.accounts.map((e: any) => globalThis.String(e)) : [],
-      parsed: isObject(object.parsed) ? object.parsed : undefined,
+      rawParsed: isSet(object.rawParsed)
+        ? globalThis.String(object.rawParsed)
+        : isSet(object.raw_parsed)
+        ? globalThis.String(object.raw_parsed)
+        : undefined,
       rawTransaction: isSet(object.rawTransaction)
         ? globalThis.String(object.rawTransaction)
         : isSet(object.raw_transaction)
@@ -10690,8 +10694,8 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
     if (message.accounts?.length) {
       obj.accounts = message.accounts;
     }
-    if (message.parsed !== undefined) {
-      obj.parsed = message.parsed;
+    if (message.rawParsed !== undefined) {
+      obj.rawParsed = message.rawParsed;
     }
     if (message.rawTransaction !== undefined) {
       obj.rawTransaction = message.rawTransaction;
@@ -10708,7 +10712,7 @@ export const Data_SolInstruction: MessageFns<Data_SolInstruction> = {
     message.slot = object.slot ?? 0n;
     message.programAccountId = object.programAccountId ?? "";
     message.accounts = object.accounts?.map((e) => e) || [];
-    message.parsed = object.parsed ?? undefined;
+    message.rawParsed = object.rawParsed ?? undefined;
     message.rawTransaction = object.rawTransaction ?? undefined;
     return message;
   },

--- a/packages/sdk/src/solana/solana-plugin.ts
+++ b/packages/sdk/src/solana/solana-plugin.ts
@@ -103,8 +103,10 @@ export class SolanaPlugin extends Plugin {
         let parsedInstruction: SolInstruction | null = null
 
         try {
-          if (instruction.parsed) {
-            parsedInstruction = processor.getParsedInstruction(instruction.parsed as { type: string; info: any })
+          if (instruction.rawParsed) {
+            parsedInstruction = processor.getParsedInstruction(
+              JSON.parse(instruction.rawParsed) as { type: string; info: any }
+            )
           } else if (instruction.instructionData) {
             parsedInstruction = processor.getParsedInstruction(instruction.instructionData)
           }

--- a/packages/sdk/src/solana/tests/pyusd-token-2022.test.ts
+++ b/packages/sdk/src/solana/tests/pyusd-token-2022.test.ts
@@ -28,7 +28,7 @@ describe('Test SPL Token 2022 Example', () => {
         instructionData: '',
         slot: 100n,
         programAccountId: SPL_TOKEN_2022_PROGRAM_ID,
-        parsed: {
+        rawParsed: JSON.stringify({
           type: 'mintTo',
           info: {
             account: '2SDN4vEJdCdW3pGyhx2km9gB3LeHzMGLrG2j4uVNZfrx',
@@ -36,7 +36,7 @@ describe('Test SPL Token 2022 Example', () => {
             mint: PYUSD_MINT,
             mintAuthority: 'BCD75RNBHrJJpW4dXVagL5mPjzRLnVZq4YirJdjEYMV7'
           }
-        },
+        }),
         accounts: []
       }
     ]
@@ -52,7 +52,7 @@ describe('Test SPL Token 2022 Example', () => {
         instructionData: '',
         slot: 101n,
         programAccountId: SPL_TOKEN_2022_PROGRAM_ID,
-        parsed: {
+        rawParsed: JSON.stringify({
           type: 'transferChecked',
           info: {
             source: '11111111111111111111111111111111',
@@ -65,7 +65,7 @@ describe('Test SPL Token 2022 Example', () => {
               uiAmountString: '2.0'
             }
           }
-        },
+        }),
         accounts: []
       }
     ]
@@ -81,7 +81,7 @@ describe('Test SPL Token 2022 Example', () => {
         instructionData: '',
         slot: 102n,
         programAccountId: SPL_TOKEN_2022_PROGRAM_ID,
-        parsed: {
+        rawParsed: JSON.stringify({
           type: 'mintTo',
           info: {
             account: '2SDN4vEJdCdW3pGyhx2km9gB3LeHzMGLrG2j4uVNZfrx',
@@ -89,7 +89,7 @@ describe('Test SPL Token 2022 Example', () => {
             mint: OTHER_MINT,
             mintAuthority: 'BCD75RNBHrJJpW4dXVagL5mPjzRLnVZq4YirJdjEYMV7'
           }
-        },
+        }),
         accounts: []
       }
     ]

--- a/packages/sdk/src/solana/tests/wormhole-token-bridge.test.ts
+++ b/packages/sdk/src/solana/tests/wormhole-token-bridge.test.ts
@@ -61,7 +61,7 @@ describe('Test Solana Example', () => {
         instructionData: '',
         slot: 0n,
         programAccountId: 'wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb',
-        parsed: parsedIns,
+        rawParsed: JSON.stringify(parsedIns),
         accounts: []
       }
     ]


### PR DESCRIPTION
## Summary

The `Data.SolInstruction` proto field `parsed` (`google.protobuf.Struct`, field 4) is replaced with `raw_parsed` (`string`, field 7). The backend now sends the parsed instruction as a JSON string instead of a structured `Struct`, and the SDK `JSON.parse`s it before dispatching to instruction handlers.

## Changes

- **proto + generated TS**: `processor.proto` field rename and regenerated bindings in `packages/protos` and `packages/runtime`.
- **`packages/sdk/src/solana/solana-plugin.ts`**: consumer now reads `instruction.rawParsed` and `JSON.parse`s it:
  ```ts
  if (instruction.rawParsed) {
    parsedInstruction = processor.getParsedInstruction(
      JSON.parse(instruction.rawParsed) as { type: string; info: any }
    )
  }
  ```
- **test fixtures** (`pyusd-token-2022.test.ts`, `wormhole-token-bridge.test.ts`): build instructions with `rawParsed: JSON.stringify({ type, info })` instead of `parsed: { type, info }`.

## Note

Test fixtures assign the instruction object literal to a `const` before passing it to `testInstructions`, which bypasses TypeScript's excess-property check — so a stale `parsed:` field would compile clean but be dropped at runtime. All fixtures were converted and verified via the test suite, not just `tsc`.

## Test plan

- `@sentio/protos`, `@sentio/runtime`, `@sentio/sdk`, `@sentio/cli` build clean
- Full SDK test suite: **170 tests, 0 failures** (all 7 Solana tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)