### PR TITLE
fix(runtime): back-fill move resource change types from deprecated singular type

### DIFF
--- a/packages/runtime/src/full-service.test.ts
+++ b/packages/runtime/src/full-service.test.ts
@@ -1,7 +1,8 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import { RuntimeServicePatcher } from './full-service.js'
-import { DataBinding, HandlerType } from './gen/processor/protos/processor.js'
+import { DataBinding, HandlerType, ProcessConfigResponse } from './gen/processor/protos/processor.js'
+import { DeepPartial } from '@sentio/protos'
 
 // Verifies the back-compat path for the EthBlock/EthTrace structpb -> raw_*
 // migration: once a new driver stops sending the deprecated structpb `block` /
@@ -137,5 +138,40 @@ describe('RuntimeServicePatcher solana raw_* compatibility', () => {
     }
     patcher.adjustDataBinding(binding)
     assert.deepEqual(binding.data?.solInstruction?.parsed, parsed)
+  })
+})
+
+// Verifies the config-direction back-compat for move resource/object change handlers:
+// SDKs before the plural `types` field (< 3.4.1) only set the deprecated singular
+// `type`. The latest driver reads `types` only, so patchConfig must back-fill it.
+describe('RuntimeServicePatcher move resource change type -> types compatibility', () => {
+  const patcher = new RuntimeServicePatcher()
+
+  test('contractConfigs: back-fills types from the deprecated singular type', () => {
+    const config: DeepPartial<ProcessConfigResponse> = {
+      contractConfigs: [{ moveResourceChangeConfigs: [{ type: '0x2::coin::Coin', handlerId: 0, handlerName: 'h' }] }]
+    }
+    patcher.patchConfig(config)
+    assert.deepEqual(config.contractConfigs?.[0]?.moveResourceChangeConfigs?.[0]?.types, ['0x2::coin::Coin'])
+  })
+
+  test('accountConfigs: back-fills types from the deprecated singular type', () => {
+    const config: DeepPartial<ProcessConfigResponse> = {
+      accountConfigs: [
+        { moveResourceChangeConfigs: [{ type: '0x1::aptos_coin::AptosCoin', handlerId: 0, handlerName: 'h' }] }
+      ]
+    }
+    patcher.patchConfig(config)
+    assert.deepEqual(config.accountConfigs?.[0]?.moveResourceChangeConfigs?.[0]?.types, ['0x1::aptos_coin::AptosCoin'])
+  })
+
+  test('leaves already-populated types untouched', () => {
+    const config: DeepPartial<ProcessConfigResponse> = {
+      contractConfigs: [
+        { moveResourceChangeConfigs: [{ type: 'old', types: ['new'], handlerId: 0, handlerName: 'h' }] }
+      ]
+    }
+    patcher.patchConfig(config)
+    assert.deepEqual(config.contractConfigs?.[0]?.moveResourceChangeConfigs?.[0]?.types, ['new'])
   })
 })

--- a/packages/runtime/src/full-service.ts
+++ b/packages/runtime/src/full-service.ts
@@ -265,6 +265,17 @@ export class RuntimeServicePatcher {
   patchConfig(config: DeepPartial<ProcessConfigResponse>): void {
     config.executionConfig = ExecutionConfig.fromPartial(GLOBAL_CONFIG.execution)
 
+    // Move resource/object change handlers before the plural `types` field (SDK < 3.4.1)
+    // only set the deprecated singular `type`. The latest driver reads `types` only, so
+    // back-fill it here. Resource change configs live under both contract and account configs.
+    for (const cfg of [...(config.contractConfigs ?? []), ...(config.accountConfigs ?? [])]) {
+      for (const rc of cfg.moveResourceChangeConfigs ?? []) {
+        if (!rc.types?.length && rc.type) {
+          rc.types = [rc.type]
+        }
+      }
+    }
+
     if (config.contractConfigs) {
       for (const contract of config.contractConfigs) {
         // for old fuel processor


### PR DESCRIPTION
## Why

`MoveResourceChangeConfig` (Aptos resource change, Sui/Iota object change handlers) carried a singular `type` field until SDK **v3.4.1**, which added the plural `repeated string types = 5` and switched producers to write `types`. The singular `type` was marked deprecated then and is removed entirely in v4.

A processor built with **SDK < 3.4.1** (all v2.x + early v3.x) still emits the config with only the singular `type`. Now that consumers standardize on the plural `types`, those older processors' resource-change / object-change handlers lose their configured type filter.

Per the runtime-as-compat-layer model (latest-of-major runtime hosts the user-pinned SDK), the upgrade belongs in the runtime.

## What

`patchConfig` now back-fills `types` from the deprecated singular `type` for `MoveResourceChangeConfig` under **both** `contractConfigs` and `accountConfigs` (Aptos resource-change handlers live under account configs). The check is presence-based (`!types?.length && type`), so it is a no-op for v3.4.1+ processors that already set `types`.

## Test

Added `RuntimeServicePatcher move resource change type -> types compatibility` cases to `full-service.test.ts` (contract + account back-fill, and leaves populated `types` untouched). `tsc --noEmit` and the runtime patcher tests pass (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)