### PR TITLE
fix(runtime): backport move resource change `types` field for old-SDK compat

### DIFF
--- a/packages/protos/processor.proto
+++ b/packages/protos/processor.proto
@@ -459,6 +459,7 @@ message MoveCallHandlerConfig {
 
 message MoveResourceChangeConfig {
   string type = 1;
+  repeated string types = 5;
   bool include_deleted = 4;
   int32 handler_id = 2;
   string handler_name = 3;

--- a/packages/protos/src/processor/protos/processor.ts
+++ b/packages/protos/src/processor/protos/processor.ts
@@ -822,6 +822,7 @@ export interface MoveCallHandlerConfig {
 
 export interface MoveResourceChangeConfig {
   type: string;
+  types: string[];
   includeDeleted: boolean;
   handlerId: number;
   handlerName: string;
@@ -6316,13 +6317,16 @@ export const MoveCallHandlerConfig = {
 };
 
 function createBaseMoveResourceChangeConfig(): MoveResourceChangeConfig {
-  return { type: "", includeDeleted: false, handlerId: 0, handlerName: "" };
+  return { type: "", types: [], includeDeleted: false, handlerId: 0, handlerName: "" };
 }
 
 export const MoveResourceChangeConfig = {
   encode(message: MoveResourceChangeConfig, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.type !== "") {
       writer.uint32(10).string(message.type);
+    }
+    for (const v of message.types) {
+      writer.uint32(42).string(v!);
     }
     if (message.includeDeleted !== false) {
       writer.uint32(32).bool(message.includeDeleted);
@@ -6349,6 +6353,13 @@ export const MoveResourceChangeConfig = {
           }
 
           message.type = reader.string();
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.types.push(reader.string());
           continue;
         case 4:
           if (tag !== 32) {
@@ -6383,6 +6394,7 @@ export const MoveResourceChangeConfig = {
   fromJSON(object: any): MoveResourceChangeConfig {
     return {
       type: isSet(object.type) ? globalThis.String(object.type) : "",
+      types: globalThis.Array.isArray(object?.types) ? object.types.map((e: any) => globalThis.String(e)) : [],
       includeDeleted: isSet(object.includeDeleted) ? globalThis.Boolean(object.includeDeleted) : false,
       handlerId: isSet(object.handlerId) ? globalThis.Number(object.handlerId) : 0,
       handlerName: isSet(object.handlerName) ? globalThis.String(object.handlerName) : "",
@@ -6393,6 +6405,9 @@ export const MoveResourceChangeConfig = {
     const obj: any = {};
     if (message.type !== "") {
       obj.type = message.type;
+    }
+    if (message.types?.length) {
+      obj.types = message.types;
     }
     if (message.includeDeleted !== false) {
       obj.includeDeleted = message.includeDeleted;
@@ -6412,6 +6427,7 @@ export const MoveResourceChangeConfig = {
   fromPartial(object: DeepPartial<MoveResourceChangeConfig>): MoveResourceChangeConfig {
     const message = createBaseMoveResourceChangeConfig();
     message.type = object.type ?? "";
+    message.types = object.types?.map((e) => e) || [];
     message.includeDeleted = object.includeDeleted ?? false;
     message.handlerId = object.handlerId ?? 0;
     message.handlerName = object.handlerName ?? "";

--- a/packages/runtime/src/full-service.test.ts
+++ b/packages/runtime/src/full-service.test.ts
@@ -1,7 +1,8 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import { RuntimeServicePatcher } from './full-service.js'
-import { DataBinding, HandlerType } from './gen/processor/protos/processor.js'
+import { DataBinding, HandlerType, ProcessConfigResponse } from './gen/processor/protos/processor.js'
+import { DeepPartial } from '@sentio/protos'
 
 // Verifies the back-compat path for the EthBlock/EthTrace structpb -> raw_*
 // migration: once a new driver stops sending the deprecated structpb `block` /
@@ -137,5 +138,40 @@ describe('RuntimeServicePatcher solana raw_* compatibility', () => {
     }
     patcher.adjustDataBinding(binding)
     assert.deepEqual(binding.data?.solInstruction?.parsed, parsed)
+  })
+})
+
+// Verifies the config-direction back-compat for move resource/object change handlers:
+// SDKs before the plural `types` field (< 3.4.1) only set the deprecated singular
+// `type`. The latest driver reads `types` only, so patchConfig must back-fill it.
+describe('RuntimeServicePatcher move resource change type -> types compatibility', () => {
+  const patcher = new RuntimeServicePatcher()
+
+  test('contractConfigs: back-fills types from the deprecated singular type', () => {
+    const config: DeepPartial<ProcessConfigResponse> = {
+      contractConfigs: [{ moveResourceChangeConfigs: [{ type: '0x2::coin::Coin', handlerId: 0, handlerName: 'h' }] }]
+    }
+    patcher.patchConfig(config)
+    assert.deepEqual(config.contractConfigs?.[0]?.moveResourceChangeConfigs?.[0]?.types, ['0x2::coin::Coin'])
+  })
+
+  test('accountConfigs: back-fills types from the deprecated singular type', () => {
+    const config: DeepPartial<ProcessConfigResponse> = {
+      accountConfigs: [
+        { moveResourceChangeConfigs: [{ type: '0x1::aptos_coin::AptosCoin', handlerId: 0, handlerName: 'h' }] }
+      ]
+    }
+    patcher.patchConfig(config)
+    assert.deepEqual(config.accountConfigs?.[0]?.moveResourceChangeConfigs?.[0]?.types, ['0x1::aptos_coin::AptosCoin'])
+  })
+
+  test('leaves already-populated types untouched', () => {
+    const config: DeepPartial<ProcessConfigResponse> = {
+      contractConfigs: [
+        { moveResourceChangeConfigs: [{ type: 'old', types: ['new'], handlerId: 0, handlerName: 'h' }] }
+      ]
+    }
+    patcher.patchConfig(config)
+    assert.deepEqual(config.contractConfigs?.[0]?.moveResourceChangeConfigs?.[0]?.types, ['new'])
   })
 })

--- a/packages/runtime/src/full-service.ts
+++ b/packages/runtime/src/full-service.ts
@@ -285,6 +285,17 @@ export class RuntimeServicePatcher {
   patchConfig(config: DeepPartial<ProcessConfigResponse>): void {
     config.executionConfig = ExecutionConfig.fromPartial(GLOBAL_CONFIG.execution)
 
+    // Move resource/object change handlers before the plural `types` field (SDK < 3.4.1)
+    // only set the deprecated singular `type`. The latest driver reads `types` only, so
+    // back-fill it here. Resource change configs live under both contract and account configs.
+    for (const cfg of [...(config.contractConfigs ?? []), ...(config.accountConfigs ?? [])]) {
+      for (const rc of cfg.moveResourceChangeConfigs ?? []) {
+        if (!rc.types?.length && rc.type) {
+          rc.types = [rc.type]
+        }
+      }
+    }
+
     if (config.contractConfigs) {
       for (const contract of config.contractConfigs) {
         // for old fuel processor

--- a/packages/runtime/src/gen/processor/protos/processor.ts
+++ b/packages/runtime/src/gen/processor/protos/processor.ts
@@ -828,6 +828,7 @@ export interface MoveCallHandlerConfig {
 
 export interface MoveResourceChangeConfig {
   type: string;
+  types: string[];
   includeDeleted: boolean;
   handlerId: number;
   handlerName: string;
@@ -6406,13 +6407,16 @@ export const MoveCallHandlerConfig = {
 };
 
 function createBaseMoveResourceChangeConfig(): MoveResourceChangeConfig {
-  return { type: "", includeDeleted: false, handlerId: 0, handlerName: "" };
+  return { type: "", types: [], includeDeleted: false, handlerId: 0, handlerName: "" };
 }
 
 export const MoveResourceChangeConfig = {
   encode(message: MoveResourceChangeConfig, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.type !== "") {
       writer.uint32(10).string(message.type);
+    }
+    for (const v of message.types) {
+      writer.uint32(42).string(v!);
     }
     if (message.includeDeleted !== false) {
       writer.uint32(32).bool(message.includeDeleted);
@@ -6439,6 +6443,13 @@ export const MoveResourceChangeConfig = {
           }
 
           message.type = reader.string();
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.types.push(reader.string());
           continue;
         case 4:
           if (tag !== 32) {
@@ -6473,6 +6484,7 @@ export const MoveResourceChangeConfig = {
   fromJSON(object: any): MoveResourceChangeConfig {
     return {
       type: isSet(object.type) ? globalThis.String(object.type) : "",
+      types: globalThis.Array.isArray(object?.types) ? object.types.map((e: any) => globalThis.String(e)) : [],
       includeDeleted: isSet(object.includeDeleted) ? globalThis.Boolean(object.includeDeleted) : false,
       handlerId: isSet(object.handlerId) ? globalThis.Number(object.handlerId) : 0,
       handlerName: isSet(object.handlerName) ? globalThis.String(object.handlerName) : "",
@@ -6483,6 +6495,9 @@ export const MoveResourceChangeConfig = {
     const obj: any = {};
     if (message.type !== "") {
       obj.type = message.type;
+    }
+    if (message.types?.length) {
+      obj.types = message.types;
     }
     if (message.includeDeleted !== false) {
       obj.includeDeleted = message.includeDeleted;
@@ -6502,6 +6517,7 @@ export const MoveResourceChangeConfig = {
   fromPartial(object: DeepPartial<MoveResourceChangeConfig>): MoveResourceChangeConfig {
     const message = createBaseMoveResourceChangeConfig();
     message.type = object.type ?? "";
+    message.types = object.types?.map((e) => e) || [];
     message.includeDeleted = object.includeDeleted ?? false;
     message.handlerId = object.handlerId ?? 0;
     message.handlerName = object.handlerName ?? "";

--- a/packages/sdk/src/aptos/aptos-plugin.ts
+++ b/packages/sdk/src/aptos/aptos-plugin.ts
@@ -149,6 +149,7 @@ export class AptosPlugin extends Plugin {
           handlerId: handlerId,
           handlerName: handler.handlerName,
           type: handler.type,
+          types: [handler.type],
           includeDeleted: false
         })
       }
@@ -213,6 +214,7 @@ export class AptosPlugin extends Plugin {
             handlerId,
             handlerName: handler.handlerName,
             type: handler.type,
+            types: [handler.type],
             includeDeleted: false
           })
         }

--- a/packages/sdk/src/iota/iota-plugin-part.ts
+++ b/packages/sdk/src/iota/iota-plugin-part.ts
@@ -129,6 +129,7 @@ export class IotaPluginPart {
         const handlerId = this.handlerRegister.register(handler.handler, chainId)
         const objectChangeHandler: MoveResourceChangeConfig = {
           type: handler.type,
+          types: [handler.type],
           handlerId,
           handlerName: handler.handlerName,
           includeDeleted: false
@@ -154,6 +155,7 @@ export class IotaPluginPart {
         const handlerId = this.handlerRegister.register(handler.handler, chainId)
         const objectChangeHandler: MoveResourceChangeConfig = {
           type: handler.type,
+          types: [handler.type],
           handlerId,
           handlerName: handler.handlerName,
           includeDeleted: false

--- a/packages/sdk/src/iota/tests/iota.test.ts
+++ b/packages/sdk/src/iota/tests/iota.test.ts
@@ -54,6 +54,9 @@ describe('Test Iota Example', () => {
     expect(config.accountConfigs[1].moveResourceChangeConfigs[0].type).eq(
       dynamic_field.Field.type(BUILTIN_TYPES.U64_TYPE, validator.ValidatorV1.type()).getSignature()
     )
+    expect(config.accountConfigs[1].moveResourceChangeConfigs[0].types).deep.eq([
+      dynamic_field.Field.type(BUILTIN_TYPES.U64_TYPE, validator.ValidatorV1.type()).getSignature()
+    ])
   })
 
   test('Check event dispatch', async () => {

--- a/packages/sdk/src/sui/sui-plugin-part.ts
+++ b/packages/sdk/src/sui/sui-plugin-part.ts
@@ -129,6 +129,7 @@ export class SuiPluginPart {
         const handlerId = this.handlerRegister.register(handler.handler, chainId)
         const objectChangeHandler: MoveResourceChangeConfig = {
           type: handler.type,
+          types: [handler.type],
           handlerId,
           handlerName: handler.handlerName,
           includeDeleted: false
@@ -154,6 +155,7 @@ export class SuiPluginPart {
         const handlerId = this.handlerRegister.register(handler.handler, chainId)
         const objectChangeHandler: MoveResourceChangeConfig = {
           type: handler.type,
+          types: [handler.type],
           handlerId,
           handlerName: handler.handlerName,
           includeDeleted: false

--- a/packages/sdk/src/sui/tests/sui.test.ts
+++ b/packages/sdk/src/sui/tests/sui.test.ts
@@ -54,6 +54,9 @@ describe('Test Sui Example', () => {
     expect(config.accountConfigs[1].moveResourceChangeConfigs[0].type).eq(
       dynamic_field.Field.type(BUILTIN_TYPES.U64_TYPE, validator.Validator.type()).getSignature()
     )
+    expect(config.accountConfigs[1].moveResourceChangeConfigs[0].types).deep.eq([
+      dynamic_field.Field.type(BUILTIN_TYPES.U64_TYPE, validator.Validator.type()).getSignature()
+    ])
   })
 
   test('Check event dispatch', async () => {


### PR DESCRIPTION
## Why

On v2, `MoveResourceChangeConfig` (Aptos resource change, Sui/Iota object change handlers) only carried the singular `type` field. The plural `repeated string types` was introduced in SDK **v3.4.1** and consumers now standardize on it. A processor on the v2 line therefore emits only `type`, and its resource-change / object-change handlers lose their configured type filter against current consumers.

Companion to the v3 fix (#65). v2 needs more than the patcher because the proto itself lacked the field.

## What

- **proto + generated `@sentio/protos` + runtime gen**: add `repeated string types = 5` to `MoveResourceChangeConfig` (additive — `type` is retained for wire/back-compat).
- **aptos / sui / iota plugins**: emit `types` alongside the existing `type`, so the latest v2 SDK populates the new field directly.
- **runtime `patchConfig`**: back-fill `types` from the deprecated singular `type` for processors built before the field existed (covers both `contractConfigs` and `accountConfigs`; Aptos resource-change handlers live under account configs). Presence-based (`!types?.length && type`), so it is a no-op once `types` is set.

## Codegen note

This repo has no local proto codegen, so the field-5 codec was **hand-ported from the v3 generated output** (identical ts-proto style, same field number/tag). It should be re-verified against the official codegen on the next regen.

## Test

Added `RuntimeServicePatcher move resource change type -> types compatibility` cases to `full-service.test.ts`. `tsc --noEmit` passes for `@sentio/protos` and `@sentio/runtime`; the runtime patcher tests pass (9/9). The SDK package's remaining `tsc` errors are pre-existing missing-codegen artifacts unrelated to this change (none in the edited plugin files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)