### PR TITLE
fix(ci): stop semantic-release silently swallowing '!' commits; cap them at minor

### DIFF
--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -128,7 +128,7 @@ jobs:
           ./scripts/update-version.sh @sentio/action ${{ steps.semantic.outputs.new_release_version }}
           pnpm publish --filter "@sentio/action" --no-git-checks --tag ${{ steps.npm.outputs.dist_tag }}
       - name: Clean Github Release for RC
-        if: ${{ contains(steps.semantic.outputs.new_release_version, '-') == false }}
+        if: ${{ steps.semantic.outputs.new_release_published == 'true' && contains(steps.semantic.outputs.new_release_version, '-') == false }}
         run:  ./scripts/clean-rc-releases.sh
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/packages/action/release.config.cjs
+++ b/packages/action/release.config.cjs
@@ -5,11 +5,14 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
-        preset: 'angular',
+        preset: 'conventionalcommits',
         releaseRules: [
           { type: 'release', "scope": 'major',  release: 'major' },
           { type: 'release', "scope": 'minor',  release: 'minor' },
           { type: 'release', "scope": 'patch',  release: 'patch' },
+          // '!'/BREAKING CHANGE markers are capped at minor: major releases are
+          // only ever cut explicitly via a release(major) commit.
+          { breaking: true, release: 'minor' },
           { type: 'chore', release: 'patch' },
           { type: 'refactor', release: 'patch' },
         ],

--- a/packages/cli/release.config.cjs
+++ b/packages/cli/release.config.cjs
@@ -5,11 +5,14 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
-        preset: 'angular',
+        preset: 'conventionalcommits',
         releaseRules: [
           { type: 'release', "scope": 'major',  release: 'major' },
           { type: 'release', "scope": 'minor',  release: 'minor' },
           { type: 'release', "scope": 'patch',  release: 'patch' },
+          // '!'/BREAKING CHANGE markers are capped at minor: major releases are
+          // only ever cut explicitly via a release(major) commit.
+          { breaking: true, release: 'minor' },
           { type: 'chore', release: 'patch' },
           { type: 'refactor', release: 'patch' },
         ],

--- a/release.config.js
+++ b/release.config.js
@@ -5,11 +5,14 @@ export default {
     [
       '@semantic-release/commit-analyzer',
       {
-        preset: 'angular',
+        preset: 'conventionalcommits',
         releaseRules: [
           { type: 'release', "scope": 'major',  release: 'major' },
           { type: 'release', "scope": 'minor',  release: 'minor' },
           { type: 'release', "scope": 'patch',  release: 'patch' },
+          // '!'/BREAKING CHANGE markers are capped at minor: major releases are
+          // only ever cut explicitly via a release(major) commit.
+          { breaking: true, release: 'minor' },
           { type: 'chore', release: 'patch' },
           { type: 'refactor', release: 'patch' },
         ],

--- a/scripts/clean-rc-releases.sh
+++ b/scripts/clean-rc-releases.sh
@@ -1,1 +1,7 @@
-gh release list | grep Pre-release | awk '{print $1;}' | xargs -L1 gh release delete
+#!/bin/bash
+set -euo pipefail
+
+# Delete pre-release GitHub releases (keeps their git tags, which semantic-release relies on).
+gh release list --limit 1000 --json tagName,isPrerelease \
+  --jq '.[] | select(.isPrerelease) | .tagName' |
+  xargs -r -L1 gh release delete --yes


### PR DESCRIPTION
## Why

Pushes of `feat!:` / `feat(scope)!:` commits to `main` were not cutting a release — see [run 27248868191](https://github.com/sentioxyz/sentio-sdk/actions/runs/27248868191/job/80468779523), where all 4 such commits since `v4.0.0-rc.1` (#68, #67, #64, #59) were analyzed as "no release".

Root cause: `@semantic-release/commit-analyzer` was configured with the **angular** preset, whose header parser (`/^(\w*)(?:\((.*)\))?: (.*)$/`) does not accept the conventional-commits `!` marker. The header fails to parse, the commit type comes out empty, and no release rule matches — the commit is silently swallowed.

## What

**Release configs** (root, `packages/cli`, `packages/action`):
- Switch the commit-analyzer preset from `angular` to `conventionalcommits` — the same preset `release-notes-generator` already uses, and `conventional-changelog-conventionalcommits` is already a root devDependency.
- Add `{ breaking: true, release: 'minor' }`: `!` / `BREAKING CHANGE:` commits now cut **at most a minor**. Major releases remain exclusively under manual control via `release(major)` commits (project policy) — the `!` marker can no longer bump a major, but it also can no longer silently produce no release.

Verified against the real installed analyzer (`@semantic-release/commit-analyzer@13.0.1`), 20 cases: the 4 commits above → `minor`; `fix!`/`chore!`/`docs!`/`BREAKING CHANGE:` footer → `minor`; `release(major|minor|patch)` → major/minor/patch unchanged; plain `feat`→minor, `fix`/`perf`/`chore`/`refactor`→patch, `docs`/`ci`/`test`→no release, all unchanged.

After merge, `main` will cut `4.0.0-rc.2` (prerelease increment on the existing rc line).

**RC cleanup** (independent bug that made the linked run red):
- The `Clean Github Release for RC` step ran on every no-release push because `contains('', '-')` is `false`; it is now also gated on `new_release_published == 'true'`.
- `scripts/clean-rc-releases.sh` crashed on empty input (`xargs` invoked `gh release delete` with no args → exit 123) and parsed fragile table output. It now uses `gh release list --json/--jq`, `xargs -r`, and `--yes` for non-interactive deletion. Git tags are kept, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)