### PR TITLE
fix(cli): retry processor upload on ECONNRESET and other transient network errors

### DIFF
--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -738,7 +738,12 @@ export async function uploadFile(
     try {
       await upload()
     } catch (e: any) {
-      if (e?.constructor.name === 'FetchError' && e.type === 'system' && e.code === 'EPIPE') {
+      // Transient network errors while PUT-ing the packed processor to the signed
+      // storage URL: node-fetch surfaces these as `FetchError` with `type: 'system'`
+      // and the underlying socket errno in `code`. Retry all of them, not just EPIPE
+      // (ECONNRESET / "socket hang up" is the most common one against GCS).
+      const RETRYABLE_CODES = ['EPIPE', 'ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'EAI_AGAIN']
+      if (e?.constructor.name === 'FetchError' && e.type === 'system' && RETRYABLE_CODES.includes(e.code)) {
         error = e
         await new Promise((resolve) => setTimeout(resolve, 1000))
         await tryUploading()


### PR DESCRIPTION
## Problem

`sentio upload` fails intermittently at the final step that PUTs the packed
processor (`dist/lib.js`) to the signed storage URL, with:

```
FetchError: request to https://storage.googleapis.com/sentio-processors/upload/... failed, reason: socket hang up
  code: 'ECONNRESET'
```

Build / codegen / packaging all succeed and the signed URL is obtained fine —
only the upload PUT (via `node-fetch`) gets reset. The same PUT to the same GCS
host succeeds reliably via `curl` and via Node's built-in `fetch` (undici), so
the reset is a transient connection issue that `node-fetch` 2.x surfaces and
does not transparently retry.

## Root cause

The retry guard in `tryUploading` only matched `EPIPE`:

```ts
if (e?.constructor.name === 'FetchError' && e.type === 'system' && e.code === 'EPIPE') {
```

`ECONNRESET` (the common one against GCS) fell through to the `else` branch and
aborted the whole upload after a single attempt — no retry — even though the
`triedCount`/backoff machinery was already in place for up to 5 tries.

## Fix

Widen the retry whitelist to the common transient socket errnos
(`ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, `EAI_AGAIN`) in addition to `EPIPE`.
No behavior change for non-transient errors (they still surface immediately).

## Test

Reproduced the `ECONNRESET` reliably (intermittent) with `node-fetch` 2.7.0
PUT-ing ~5MB to the GCS bucket host; undici and curl never reset. After the
change, a reset triggers the existing 1s-delay retry loop instead of aborting,
which is what lets the upload succeed on a subsequent attempt.