### PR TITLE
fix(sui): normalize gRPC protojson objects/events to SuiClientTypes at SDK boundary

### DIFF
--- a/packages/sdk/src/sui/sui-object-processor.ts
+++ b/packages/sdk/src/sui/sui-object-processor.ts
@@ -25,6 +25,7 @@ import { CallHandler, TransactionFilter, accountTypeString, ObjectChangeHandler 
 import { ConnectError, Code } from '@connectrpc/connect'
 import { TypeDescriptor } from '@typemove/move'
 import { TypedSuiMoveObject } from './models.js'
+import { toSuiClientObject } from './to-client-types.js'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 
 export interface SuiObjectBindOptions {
@@ -190,7 +191,10 @@ export class SuiAddressProcessor extends SuiBaseObjectOrAddressProcessorInternal
     data: Data_SuiObject,
     ctx: SuiObjectContext
   ) {
-    return handler(data.rawObjects.map((o) => JSON.parse(o)) as SuiMoveObjectInput[], ctx)
+    return handler(
+      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
+      ctx
+    )
   }
 
   onTransactionBlock(
@@ -267,8 +271,8 @@ export class SuiObjectProcessor extends SuiBaseObjectOrAddressProcessorInternal<
       return
     }
     return handler(
-      JSON.parse(data.rawSelf) as SuiMoveObjectInput,
-      data.rawObjects.map((o) => JSON.parse(o)) as SuiMoveObjectInput[],
+      toSuiClientObject(JSON.parse(data.rawSelf)),
+      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
       ctx
     )
   }
@@ -306,9 +310,13 @@ export class SuiObjectTypeProcessor<T> extends SuiBaseObjectOrAddressProcessor<
       return
     }
     const object = await ctx.coder.filterAndDecodeObjects(this.objectType, [
-      JSON.parse(data.rawSelf) as SuiMoveObjectInput
+      toSuiClientObject(JSON.parse(data.rawSelf))
     ])
-    return handler(object[0], data.rawObjects.map((o) => JSON.parse(o)) as SuiMoveObjectInput[], ctx)
+    return handler(
+      object[0],
+      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
+      ctx
+    )
   }
 
   public onObjectChange(handler: (changes: SuiObjectChange[], ctx: SuiObjectChangeContext) => PromiseOrVoid): this {
@@ -400,6 +408,9 @@ export class SuiWrappedObjectProcessor extends SuiBaseObjectOrAddressProcessorIn
     data: Data_SuiObject,
     ctx: SuiObjectContext
   ) {
-    return handler(data.rawObjects.map((o) => JSON.parse(o)) as SuiMoveObjectInput[], ctx)
+    return handler(
+      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
+      ctx
+    )
   }
 }

--- a/packages/sdk/src/sui/sui-processor.ts
+++ b/packages/sdk/src/sui/sui-processor.ts
@@ -30,6 +30,7 @@ import { ALL_ADDRESS, Labels, PromiseOrVoid } from '../core/index.js'
 import { Required } from 'utility-types'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 import { HandlerOptions } from './models.js'
+import { toSuiClientEvent } from './to-client-types.js'
 
 export const DEFAULT_FETCH_CONFIG: MoveFetchConfig = create(MoveFetchConfigSchema, {
   resourceChanges: false,
@@ -111,7 +112,7 @@ export class SuiBaseProcessor {
         }
         const txn = JSON.parse(data.rawTransaction) as GrpcTypes.ExecutedTransaction
 
-        const evt = JSON.parse(data.rawEvent) as SuiEventInput
+        const evt = toSuiClientEvent(JSON.parse(data.rawEvent))
         // gRPC events carry no sequence; index is resolved by the runtime.
         const idx = 0
 
@@ -137,7 +138,7 @@ export class SuiBaseProcessor {
         const p = handlerOptions?.partitionKey
         if (!p) return undefined
         if (typeof p === 'function') {
-          const evt = JSON.parse(data.rawEvent) as SuiEventInput
+          const evt = toSuiClientEvent(JSON.parse(data.rawEvent))
           const decoded = await processor.coder.decodeEvent<any>(evt)
           return p((decoded || evt) as T)
         }

--- a/packages/sdk/src/sui/tests/to-client-types.test.ts
+++ b/packages/sdk/src/sui/tests/to-client-types.test.ts
@@ -1,0 +1,71 @@
+import { describe, test } from 'node:test'
+import { expect } from 'chai'
+import { defaultMoveCoder } from '../move-coder.js'
+import { loadAllTypes } from '../builtin/0x2.js'
+import { SuiNetwork } from '../network.js'
+import { parseMoveType } from '../../move/index.js'
+import { toSuiClientObject } from '../to-client-types.js'
+
+// Raw protojson of a `sui.rpc.v2.Object` exactly as the Sentio driver emits it
+// (BatchGetObjects -> protojson.Marshal): note `objectType` / `owner.kind` /
+// `contents`, not the unified `type` / `owner.$kind`.
+const grpcObject = {
+  objectId: '0xc061d544681939544136efac81d212de377e2ff13eb07ef9079404ebd57cad5d',
+  version: '309855314',
+  digest: '97mrov7YttYFH7j2gz7TkYu9quXZC4zs4cXkifNGcWrn',
+  owner: { kind: 'OBJECT', address: '0x4846a1f1030deffd9dea59016402d832588cf7e0c27b9e4c1a63d2b5e152873a' },
+  objectType:
+    '0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_object_field::Wrapper<address>,0x0000000000000000000000000000000000000000000000000000000000000002::object::ID>',
+  hasPublicTransfer: false,
+  contents: { name: 'Object', value: 'd0dV' },
+  json: {
+    id: '0xc061d544681939544136efac81d212de377e2ff13eb07ef9079404ebd57cad5d',
+    name: { name: '0xe859a7ebc84e7573d1e81ef99946f8821aeb0ff67454e579a32dd216da239621' },
+    value: '0xc0254d60d00d9215c3a878ad2ea020aeebfb336eb143e5919a8209e71db998a0'
+  }
+}
+
+describe('toSuiClientObject', () => {
+  test('maps gRPC protojson Object to unified SuiClientTypes shape', () => {
+    const o = toSuiClientObject(grpcObject) as any
+    expect(o.type).equals(grpcObject.objectType) // objectType -> type
+    expect(o.objectId).equals(grpcObject.objectId)
+    expect(o.version).equals(grpcObject.version)
+    expect(o.owner.$kind).equals('ObjectOwner') // {kind:'OBJECT'} -> ObjectOwner
+    expect(o.owner.ObjectOwner).equals(grpcObject.owner.address)
+    expect(o.json).deep.equals(grpcObject.json)
+  })
+
+  test('owner kinds map to the unified union', () => {
+    expect((toSuiClientObject({ owner: { kind: 'ADDRESS', address: '0x1' } }) as any).owner).deep.equals({
+      $kind: 'AddressOwner',
+      AddressOwner: '0x1'
+    })
+    expect((toSuiClientObject({ owner: { kind: 'IMMUTABLE' } }) as any).owner).deep.equals({
+      $kind: 'Immutable',
+      Immutable: true
+    })
+    expect((toSuiClientObject({ owner: { kind: 'SHARED', version: '7' } }) as any).owner).deep.equals({
+      $kind: 'Shared',
+      Shared: { initialSharedVersion: '7' }
+    })
+  })
+
+  test('converted object decodes; the raw gRPC shape does not', async () => {
+    const coder = defaultMoveCoder(SuiNetwork.TEST_NET)
+    loadAllTypes(coder)
+    const matcher = parseMoveType(grpcObject.objectType)
+
+    // The raw shape has no `.type`, so getType() yields '' and nothing matches.
+    const rawDecoded = await coder.filterAndDecodeObjects(matcher, [grpcObject as any])
+    expect(rawDecoded.length).equals(0)
+
+    // After normalization it matches and decodes the Move struct content.
+    const decoded = await coder.filterAndDecodeObjects(matcher, [toSuiClientObject(grpcObject)])
+    expect(decoded.length).equals(1)
+    const d = decoded[0].data_decoded as any
+    expect(d.id.id).equals(grpcObject.json.id)
+    expect(d.name.name).equals(grpcObject.json.name.name) // Wrapper<address>{ name }
+    expect(d.value).equals(grpcObject.json.value) // ID -> string
+  })
+})

--- a/packages/sdk/src/sui/to-client-types.ts
+++ b/packages/sdk/src/sui/to-client-types.ts
@@ -1,0 +1,75 @@
+import type { SuiClientTypes } from '@mysten/sui/client'
+import type { SuiEventInput, SuiMoveObjectInput } from '@typemove/sui'
+
+// The Sentio driver delivers Sui objects/events as protojson of the gRPC
+// `sui.rpc.v2.{Object,Event}` messages — field names like `objectType` and
+// `contents`. typemove's decoder, and the SDK's public handler types, speak
+// the unified `@mysten/sui/client` `SuiClientTypes` shape (`type`, `bcs`).
+// Normalize at the SDK boundary so nothing downstream ever sees the raw gRPC
+// shape: `getType`/`getData` resolve cleanly (`.type` / `.json`) and the
+// decoded envelope honestly matches its declared `SuiClientTypes.Object` type.
+// `SuiGrpcClient.core` performs the equivalent mapping for standalone callers,
+// so both delivery paths converge on `SuiClientTypes` before decoding.
+
+function base64ToBytes(b64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(b64, 'base64'))
+}
+
+// Mirrors mapOwner in @mysten/sui's grpc core. protojson serializes the
+// Owner.OwnerKind enum to its proto value name and uint64 `version` to a string.
+function mapOwner(owner: any): SuiClientTypes.ObjectOwner | null {
+  if (!owner) {
+    return null
+  }
+  switch (owner.kind) {
+    case 'IMMUTABLE':
+      return { $kind: 'Immutable', Immutable: true }
+    case 'ADDRESS':
+      return { $kind: 'AddressOwner', AddressOwner: owner.address }
+    case 'OBJECT':
+      return { $kind: 'ObjectOwner', ObjectOwner: owner.address }
+    case 'SHARED':
+      return { $kind: 'Shared', Shared: { initialSharedVersion: String(owner.version) } }
+    case 'CONSENSUS_ADDRESS':
+      return {
+        $kind: 'ConsensusAddressOwner',
+        ConsensusAddressOwner: { startVersion: String(owner.version), owner: owner.address }
+      }
+    default:
+      return { $kind: 'Unknown' }
+  }
+}
+
+// protojson `sui.rpc.v2.Object` -> unified `SuiClientTypes.Object<{ json: true }>`.
+// Already-unified inputs (from `SuiGrpcClient.core`) pass through: `.type` and
+// `.json` are read with the gRPC names falling back to the unified ones. With
+// `Include = { json: true }` every field except objectId/version/digest/owner/
+// type/json is typed `undefined`, so we deliberately leave them unset.
+export function toSuiClientObject(o: any): SuiMoveObjectInput {
+  return {
+    objectId: o.objectId,
+    version: o.version,
+    digest: o.digest,
+    owner: mapOwner(o.owner)!,
+    type: o.objectType ?? o.type ?? '',
+    content: undefined,
+    previousTransaction: undefined,
+    objectBcs: undefined,
+    json: o.json ?? null,
+    display: undefined
+  } as SuiMoveObjectInput
+}
+
+// protojson `sui.rpc.v2.Event` -> unified `SuiClientTypes.Event`. The
+// discriminating fields (`eventType`, `json`) already share names; only the
+// BCS payload is renamed (`contents` -> `bcs`).
+export function toSuiClientEvent(e: any): SuiEventInput {
+  return {
+    packageId: e.packageId,
+    module: e.module,
+    sender: e.sender,
+    eventType: e.eventType ?? e.type ?? '',
+    bcs: e.contents?.value != null ? base64ToBytes(e.contents.value) : (e.bcs ?? new Uint8Array()),
+    json: e.json ?? null
+  } as SuiEventInput
+}


### PR DESCRIPTION
## Problem

The Sentio driver delivers Sui objects/events as **protojson of the gRPC `sui.rpc.v2.{Object,Event}` messages** — field names like `objectType` / `contents` / `owner.kind`. But typemove's decoder and the SDK's public handler types (`SuiMoveObjectInput` / `SuiEventInput`) speak the **unified `@mysten/sui/client` `SuiClientTypes`** shape (`type` / `json`).

The decoder's `getType` reads `.type`, so driver objects — which carry `.objectType` — yielded `''`, failed type-matching in `filterAndDecodeStruct`, and **silently never decoded**. (Events happened to work because proto `Event.eventType` already matches the unified name; only objects diverged.)

## Fix

Establish a clean layering: **before decode = gRPC wire shape, after the SDK boundary = `SuiClientTypes`**. Convert once at the `JSON.parse` sites so everything downstream — both the decoded envelope and the raw passthrough arrays handed to handlers — is `SuiClientTypes`.

- New `to-client-types.ts`:
  - `toSuiClientObject` — `objectType → type`, owner enum → unified `ObjectOwner` union (mirrors `SuiGrpcClient.core`'s `mapOwner`), `json` passthrough.
  - `toSuiClientEvent` — `eventType`/`json` already share names; only `contents → bcs`.
- Applied at the 5 `rawObjects`/`rawSelf` sites in `sui-object-processor.ts` and the 2 `rawEvent` sites in `sui-processor.ts`.
- `rawTransaction` (`GrpcTypes.ExecutedTransaction`) and `rawChanges` (jsonRpc `SuiObjectChange`) stay gRPC by design — `SuiClientTypes` doesn't model them.

**typemove is left untouched** — it stays unified-in/unified-out. `SuiGrpcClient.core` does the equivalent mapping for standalone callers, so both delivery paths converge on `SuiClientTypes` before decoding.

## Tests

- New `to-client-types.test.ts` decodes a real driver payload (a `dynamic_field::Field<Wrapper<address>, ID>`) end-to-end, asserting `id.id` / `name.name` / `value` resolve correctly. It also asserts the **raw gRPC shape decodes to 0 matches** while the converted one decodes to 1 — pinning the bug as a regression test.
- Owner-kind mapping unit tests.
- Full sui suite passes (22/22), no regressions; package builds; lint/format clean.

## Follow-up (not in this PR)

- **iota** mirrors this structure but uses `@iota/iota-sdk` (different gRPC migration state) — left untouched here; worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)