### PR TITLE
refactor(runtime): migrate ChainServer to flexible Rpc config

### DIFF
--- a/packages/runtime/src/chain-config.ts
+++ b/packages/runtime/src/chain-config.ts
@@ -1,5 +1,10 @@
+export interface RpcConfig {
+  Url: string
+  Meta?: Record<string, string>
+}
+
 export interface ChainConfig {
   ChainID: string
   Https?: string[]
-  ChainServer?: string
+  Rpc?: RpcConfig
 }

--- a/packages/runtime/src/endpoints.ts
+++ b/packages/runtime/src/endpoints.ts
@@ -2,15 +2,30 @@ import path from 'path'
 import fs from 'fs-extra'
 import { ChainConfig } from './chain-config.js'
 
+/**
+ * Resolved RPC endpoint for a chain: the base URL plus optional gRPC metadata
+ * (key-value pairs) attached to every request, e.g. the `authority` routing key
+ * for the Sui gRPC client talking to the Sentio rpc-node.
+ */
+export interface ChainRpc {
+  url: string
+  meta?: Record<string, string>
+}
+
 export class Endpoints {
   static INSTANCE: Endpoints = new Endpoints()
 
   concurrency = 8
   priceFeedAPI = ''
 
-  chainServer = new Map<string, string>()
+  chainRpc = new Map<string, ChainRpc>()
 
   batchCount = 1
+
+  /** Convenience accessor for callers that only need the endpoint URL. */
+  getChainRpcUrl(chainId: string): string | undefined {
+    return this.chainRpc.get(chainId)?.url
+  }
 }
 
 export function configureEndpoints(options: any) {
@@ -30,12 +45,15 @@ export function configureEndpoints(options: any) {
 
   for (const [id, config] of Object.entries(chainsConfig)) {
     const chainConfig = config as ChainConfig
-    if (chainConfig.ChainServer) {
-      Endpoints.INSTANCE.chainServer.set(id, chainConfig.ChainServer)
+    if (chainConfig.Rpc?.Url) {
+      Endpoints.INSTANCE.chainRpc.set(id, {
+        url: chainConfig.Rpc.Url,
+        meta: chainConfig.Rpc.Meta
+      })
     } else {
       const http = chainConfig.Https?.[0]
       if (http) {
-        Endpoints.INSTANCE.chainServer.set(id, http)
+        Endpoints.INSTANCE.chainRpc.set(id, { url: http })
       } else {
         console.error('not valid config for chain', id)
       }

--- a/packages/runtime/src/provider.test.ts
+++ b/packages/runtime/src/provider.test.ts
@@ -8,7 +8,7 @@ import { GLOBAL_CONFIG } from './global-config.js'
 
 Endpoints.INSTANCE.concurrency = 1
 Endpoints.INSTANCE.batchCount = 1
-Endpoints.INSTANCE.chainServer.set(EthChainId.ETHEREUM, 'http://localhost:12345')
+Endpoints.INSTANCE.chainRpc.set(EthChainId.ETHEREUM, { url: 'http://localhost:12345' })
 
 describe('QueuedStaticJsonRpcProvider', () => {
   test('manual retry should work', async () => {

--- a/packages/runtime/src/provider.ts
+++ b/packages/runtime/src/provider.ts
@@ -30,7 +30,7 @@ export function getProvider(chainId?: EthChainId): JsonRpcProvider {
   const network = Network.from(parseInt(chainId))
   // TODO check if other key needed
 
-  const address = Endpoints.INSTANCE.chainServer.get(chainId)
+  const address = Endpoints.INSTANCE.getChainRpcUrl(chainId)
   const key = network.chainId.toString() + '-' + address
 
   // console.debug(`init provider for ${chainId}, address: ${address}`)
@@ -45,7 +45,7 @@ export function getProvider(chainId?: EthChainId): JsonRpcProvider {
       'Provider not found for chain ' +
         network.chainId +
         ', configured chains: ' +
-        [...Endpoints.INSTANCE.chainServer.keys()].join(' ')
+        [...Endpoints.INSTANCE.chainRpc.keys()].join(' ')
     )
   }
   // console.log(

--- a/packages/sdk/src/aptos/context.ts
+++ b/packages/sdk/src/aptos/context.ts
@@ -29,11 +29,11 @@ export abstract class AptosBaseContext extends MoveContext<AptosNetwork, MoveMod
   }
 
   getClient(): RichAptosClientWithContext {
-    const chainServer = Endpoints.INSTANCE.chainServer.get(this.network)
-    if (!chainServer) {
+    const rpcUrl = Endpoints.INSTANCE.getChainRpcUrl(this.network)
+    if (!rpcUrl) {
       throw new ConnectError('RPC endpoint not provided', Code.Internal)
     }
-    const fullnode = chainServer + '/v1'
+    const fullnode = rpcUrl + '/v1'
 
     let network = Network.CUSTOM
     switch (this.network) {

--- a/packages/sdk/src/aptos/network.ts
+++ b/packages/sdk/src/aptos/network.ts
@@ -56,7 +56,7 @@ export function getRpcConfig(network: AptosNetwork, fullnode?: string | undefine
 }
 
 export function getClient(network: AptosNetwork): RichAptosClient {
-  let fullnode = Endpoints.INSTANCE.chainServer.get(network)
+  let fullnode = Endpoints.INSTANCE.getChainRpcUrl(network)
   if (fullnode) {
     if (!fullnode.endsWith('/v1')) {
       fullnode = fullnode + '/v1'

--- a/packages/sdk/src/fuel/network.ts
+++ b/packages/sdk/src/fuel/network.ts
@@ -17,11 +17,11 @@ export function getRpcEndpoint(network: FuelNetwork): string {
 }
 
 export async function getProvider(network: FuelNetwork): Promise<Provider> {
-  let chainServer = Endpoints.INSTANCE.chainServer.get(network)
-  if (!chainServer) {
-    chainServer = getRpcEndpoint(network)
+  let rpcUrl = Endpoints.INSTANCE.getChainRpcUrl(network)
+  if (!rpcUrl) {
+    rpcUrl = getRpcEndpoint(network)
     // throw new ServerError(Status.INTERNAL, 'RPC endpoint not provided')
   }
-  return new Provider(chainServer)
-  // return Provider.create(chainServer)
+  return new Provider(rpcUrl)
+  // return Provider.create(rpcUrl)
 }

--- a/packages/sdk/src/iota/network.ts
+++ b/packages/sdk/src/iota/network.ts
@@ -10,12 +10,12 @@ export const IotaNetwork = <const>{
 }
 
 export function getClient(network: IotaNetwork): IotaClient {
-  let chainServer = Endpoints.INSTANCE.chainServer.get(network)
-  if (!chainServer) {
-    chainServer = getRpcEndpoint(network)
+  let rpcUrl = Endpoints.INSTANCE.getChainRpcUrl(network)
+  if (!rpcUrl) {
+    rpcUrl = getRpcEndpoint(network)
     // throw new ConnectError('RPC endpoint not provided', Code.Internal)
   }
-  return new IotaClient({ url: chainServer })
+  return new IotaClient({ url: rpcUrl })
 }
 
 export function getRpcEndpoint(network: IotaNetwork): string {

--- a/packages/sdk/src/sui/network.ts
+++ b/packages/sdk/src/sui/network.ts
@@ -1,5 +1,5 @@
 import { SuiChainId } from '@sentio/chain'
-import { Endpoints } from '@sentio/runtime'
+import { ChainRpc, Endpoints } from '@sentio/runtime'
 import { SuiGrpcClient } from '@mysten/sui/grpc'
 
 export type SuiNetwork = SuiChainId
@@ -16,15 +16,20 @@ function inferNetworkFromUrl(url: string): string {
   return 'custom'
 }
 
-function endpointFor(network: SuiNetwork): string {
-  return Endpoints.INSTANCE.chainServer.get(network) ?? getRpcEndpoint(network)
+function rpcFor(network: SuiNetwork): ChainRpc {
+  return Endpoints.INSTANCE.chainRpc.get(network) ?? { url: getRpcEndpoint(network) }
 }
 
 // gRPC client used for the MoveCoder, generated view functions, and exposed to
 // processor handlers via `ctx.client`. @typemove/sui v2 is gRPC-only.
 export function getClient(network: SuiNetwork): SuiGrpcClient {
-  const chainServer = endpointFor(network)
-  return new SuiGrpcClient({ network: inferNetworkFromUrl(chainServer) as any, baseUrl: chainServer })
+  const { url, meta } = rpcFor(network)
+  return new SuiGrpcClient({
+    network: inferNetworkFromUrl(url) as any,
+    baseUrl: url,
+    // Metadata from the chain config (e.g. the authority routing key) is sent on every gRPC-web request.
+    meta
+  })
 }
 
 export function getRpcEndpoint(network: SuiNetwork): string {

--- a/packages/sdk/src/testing/test-processor-server.ts
+++ b/packages/sdk/src/testing/test-processor-server.ts
@@ -85,7 +85,7 @@ export class TestProcessorServer {
 
     for (const k of Object.keys(ChainInfo)) {
       const http = httpEndpoints[k] || ''
-      Endpoints.INSTANCE.chainServer.set(k, http)
+      Endpoints.INSTANCE.chainRpc.set(k, { url: http })
     }
 
     // start a memory database for testing

--- a/packages/sdk/src/testing/test-provider.ts
+++ b/packages/sdk/src/testing/test-provider.ts
@@ -15,7 +15,7 @@ export function loadTestProvidersFromEnv(requiredChainIds: string[] | string): b
       continue
     }
     found.push(k)
-    Endpoints.INSTANCE.chainServer.set(k, http)
+    Endpoints.INSTANCE.chainRpc.set(k, { url: http })
   }
 
   for (const id of requiredChainIds) {


### PR DESCRIPTION
## What

Migrate the URL-only `ChainServer` chain config to a more flexible `Rpc` block so per-chain request metadata (e.g. the rpc-node `authority` routing key) can be configured.

### Config

```json
"Rpc": {
  "Url": "http://test-rpcnode-server.test:18011",
  "Meta": { "authority": "0XhWA854-d991d2dbb38c7436-sui" }
}
```

- `RpcConfig` = `{ Url: string; Meta?: Record<string, string> }`
- The legacy `ChainServer` field is removed; the `Https` fallback is unchanged.

### Runtime

- `Endpoints.chainServer` (a `Map<string, string>`) is renamed to **`chainRpc`** and now holds `ChainRpc = { url, meta }`.
- Added `getChainRpcUrl(chainId)` helper for the URL-only consumers (eth / aptos / iota / fuel).

### Sui

- `getClient` forwards `Meta` as gRPC-web request metadata (`SuiGrpcClient` `meta` option), so the configured headers are sent on every request — this is what lets the Sui client talk to the Sentio rpc-node with its `authority` routing key.

## Test

- `packages/runtime`: 16/16 pass
- `packages/sdk`: 165 pass / 8 skipped / 0 fail
- `tsc` clean for both `@sentio/runtime` and `@sentio/sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)