### PR TITLE
feat(cli): add testnet-v2 Sentio Network support

### DIFF
--- a/packages/cli/src/commands/stop-processor.ts
+++ b/packages/cli/src/commands/stop-processor.ts
@@ -16,7 +16,7 @@ export function createStopProcessorCommand() {
   return new Command('stop')
     .description('Stop a processor. Uses Sentio Network contract when --sentio-network is specified.')
     .argument('<processorId>', 'ID of the processor to stop')
-    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet or devnet)')
+    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet, testnet-v2 or devnet)')
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -85,7 +85,10 @@ export function createUploadCommand() {
     .option('--token <token>', '(Optional) Manually provide token rather than use saved credential')
     .option('--host <host>', '(Optional) Override Sentio Host name')
     .option('--num-workers <count>', '(Optional) Number of processor workers to start', myParseInt)
-    .option('--sentio-network <network>', '(Optional) Sentio network to connect to, can be testnet, devnet or mainnet')
+    .option(
+      '--sentio-network <network>',
+      '(Optional) Sentio network to connect to, can be testnet, testnet-v2, devnet or mainnet'
+    )
     .option(
       '--required-chain-id <chain_id...>',
       '(Optional) Specify chain IDs required for the Sentio network. This option is only available when --sentio-network is used. If omitted, all chain IDs from the project configuration (contracts or network overrides) will be used.'
@@ -566,7 +569,7 @@ async function checkOrCreateProject(options: YamlProjectConfig, auth: Auth) {
     console.error(
       chalk.red(
         `Project ${project?.slug} is a Sentio Network project. Please add the --sentio-network flag when uploading.\n` +
-          `Example: sentio upload --sentio-network testnet|devnet`
+          `Example: sentio upload --sentio-network testnet|testnet-v2|devnet`
       )
     )
     process.exit(1)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,7 +34,7 @@ export interface YamlProjectConfig {
   silentOverwrite?: boolean
   variables?: Variable[]
   numWorkers?: number // Number of processor worker to start, default to 1
-  sentioNetwork?: string // Sentio network to connect to, can be testnet or mainnet
+  sentioNetwork?: string // Sentio network to connect to, can be testnet, testnet-v2, devnet or mainnet
   requiredChainIds?: string[]
 }
 
@@ -118,13 +118,19 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
       case 'devnet':
         config.sentioNetwork = '7892201'
         break
+      case 'testnet-v2':
+        config.sentioNetwork = '7892102'
+        break
       case '7892101':
       case '7892201':
+      case '7892102':
       case '789210':
         config.sentioNetwork = options.sentioNetwork
         break
       default:
-        console.error(`Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet or devnet is allowed`)
+        console.error(
+          `Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet, testnet-v2 or devnet is allowed`
+        )
         process.exit(1)
     }
   }

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -20,6 +20,13 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
   addressBookAddress: '0x092d795d42e23ecba5cc66927972be5c9980effb'
 }
 
+const TESTNET_V2_CONFIG: SentioNetworkConfig = {
+  chainId: 7892102,
+  rpcUrl: 'https://sentio-testnet-v2.rpc.sentio.xyz',
+  explorerUrl: 'https://testnet-v2-explorer.sentio.xyz',
+  addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
+}
+
 const DEVNET_CONFIG: SentioNetworkConfig = {
   chainId: 7892201,
   rpcUrl: 'https://sentio-devnet.test-rpc.sentio.xyz',
@@ -33,11 +40,17 @@ export function getSentioNetworkConfig(network: string, addressBookOverride?: st
     config = TESTNET_CONFIG
   } else if (network === 'devnet' || network === '7892201') {
     config = DEVNET_CONFIG
+  } else if (network === 'testnet-v2' || network === '7892102') {
+    config = TESTNET_V2_CONFIG
   } else if (network === 'mainnet' || network === '789210') {
-    console.error(chalk.red('Sentio Network mainnet is not yet supported. Only testnet is available.'))
+    console.error(
+      chalk.red('Sentio Network mainnet is not yet supported. Only testnet, testnet-v2 and devnet are available.')
+    )
     process.exit(1)
   } else {
-    console.error(chalk.red(`Invalid sentio network: ${network}. Only "testnet" or "devnet" is supported.`))
+    console.error(
+      chalk.red(`Invalid sentio network: ${network}. Only "testnet", "testnet-v2" or "devnet" is supported.`)
+    )
     process.exit(1)
   }
 


### PR DESCRIPTION
## What

Adds **testnet-v2** as a recognized Sentio Network target in the CLI. Previously the CLI only knew `testnet` (chainId 7892101) and `devnet` (7892201); testnet-v2 (chainId **7892102**, a distinct chain with its own explorer and AddressBook) had no entry, so `sentio upload/stop --sentio-network testnet-v2` errored out and the network could only be driven via raw `cast`.

## Changes

- **`packages/cli/src/network.ts`** — add `TESTNET_V2_CONFIG` and accept `testnet-v2` / `7892102` in `getSentioNetworkConfig`; update the unsupported/invalid messages.
  ```ts
  const TESTNET_V2_CONFIG: SentioNetworkConfig = {
    chainId: 7892102,
    rpcUrl: 'https://sentio-testnet-v2.rpc.sentio.xyz',
    explorerUrl: 'https://testnet-v2-explorer.sentio.xyz',
    addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
  }
  ```
- **`packages/cli/src/config.ts`** — add `testnet-v2` → `7892102` to `overrideConfigWithOptions` and the `7892102` passthrough case; update the invalid-network message + type comment.
- **`packages/cli/src/commands/upload.ts`**, **`stop-processor.ts`** — include `testnet-v2` in the `--sentio-network` help text and example.

## Verification (live, against the public endpoint)

- `eth_chainId` → `0x786c86` = **7892102** ✓
- `eth_blockNumber` → live, producing blocks
- `eth_sendRawTransaction` is routed (decode-error on junk, not method-not-found) → endpoint is **writable**, not a read-only proxy
- AddressBook `0xb7e9E56…0123` resolves all six module contracts the CLI needs (`processor_registry` / `controller` / `sentio_token` / `billing` / `databases` / `permissions`) via this RPC — so `resolveNetworkAddresses()` works out of the box.

## Notes

- `testnet-v2` (7892102) is a **separate chain** from the existing `testnet` (7892101) — different explorer (`testnet-v2-explorer` vs `testnet-explorer`) and different AddressBook. This PR does not touch the existing `testnet`/`devnet` entries.
- The public RPC (`sentio-testnet-v2.rpc.sentio.xyz`) was provisioned recently; an earlier note that it 404'd is now stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)