### PR TITLE
refactor(sui): migrate object-change handler types from JSON-RPC to unified SuiClientTypes

### DIFF
--- a/packages/sdk/src/sui/sui-object-processor.ts
+++ b/packages/sdk/src/sui/sui-object-processor.ts
@@ -16,8 +16,8 @@ import { create } from '@bufbuild/protobuf'
 import { ListStateStorage } from '@sentio/runtime'
 import { SuiNetwork } from './network.js'
 import { SuiAddressContext, SuiContext, SuiObjectChangeContext, SuiObjectContext } from './context.js'
-import type { SuiObjectChange } from '@mysten/sui/jsonRpc'
 import type { GrpcTypes } from '@mysten/sui/grpc'
+import type { SuiClientTypes } from '@mysten/sui/client'
 import type { SuiMoveObjectInput } from '@typemove/sui'
 import { ALL_ADDRESS, PromiseOrVoid } from '../core/index.js'
 import { configure, DEFAULT_FETCH_CONFIG, IndexConfigure, SuiBindOptions } from './sui-processor.js'
@@ -25,7 +25,7 @@ import { CallHandler, TransactionFilter, accountTypeString, ObjectChangeHandler 
 import { ConnectError, Code } from '@connectrpc/connect'
 import { TypeDescriptor } from '@typemove/move'
 import { TypedSuiMoveObject } from './models.js'
-import { toSuiClientObject } from './to-client-types.js'
+import { toSuiClientChangedObject, toSuiClientObject } from './to-client-types.js'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 
 export interface SuiObjectBindOptions {
@@ -319,7 +319,9 @@ export class SuiObjectTypeProcessor<T> extends SuiBaseObjectOrAddressProcessor<
     )
   }
 
-  public onObjectChange(handler: (changes: SuiObjectChange[], ctx: SuiObjectChangeContext) => PromiseOrVoid): this {
+  public onObjectChange(
+    handler: (changes: SuiClientTypes.ChangedObject[], ctx: SuiObjectChangeContext) => PromiseOrVoid
+  ): this {
     if (this.config.network === SuiNetwork.TEST_NET) {
       throw new ConnectError('object change not supported in testnet', Code.InvalidArgument)
     }
@@ -335,7 +337,10 @@ export class SuiObjectTypeProcessor<T> extends SuiBaseObjectOrAddressProcessor<
           data.txDigest,
           processor.config.baseLabels
         )
-        await handler(data.rawChanges.map((r) => JSON.parse(r)) as SuiObjectChange[], ctx)
+        await handler(
+          data.rawChanges.map((r) => toSuiClientChangedObject(JSON.parse(r))),
+          ctx
+        )
         return ctx.stopAndGetResult()
       },
       type: [this.objectType.getSignature()]

--- a/packages/sdk/src/sui/sui-processor.ts
+++ b/packages/sdk/src/sui/sui-processor.ts
@@ -11,8 +11,8 @@ import { ListStateStorage } from '@sentio/runtime'
 import { SuiNetwork } from './network.js'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { SuiContext, SuiObjectChangeContext } from './context.js'
-import type { SuiObjectChange } from '@mysten/sui/jsonRpc'
 import type { GrpcTypes } from '@mysten/sui/grpc'
+import type { SuiClientTypes } from '@mysten/sui/client'
 import type { SuiEventInput } from '@typemove/sui'
 import {
   accountAddressString,
@@ -30,7 +30,7 @@ import { ALL_ADDRESS, Labels, PromiseOrVoid } from '../core/index.js'
 import { Required } from 'utility-types'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 import { HandlerOptions } from './models.js'
-import { toSuiClientEvent } from './to-client-types.js'
+import { toSuiClientChangedObject, toSuiClientEvent } from './to-client-types.js'
 
 export const DEFAULT_FETCH_CONFIG: MoveFetchConfig = create(MoveFetchConfigSchema, {
   resourceChanges: false,
@@ -281,7 +281,7 @@ export class SuiBaseProcessor {
   }
 
   protected onObjectChange(
-    handler: (changes: SuiObjectChange[], ctx: SuiObjectChangeContext) => PromiseOrVoid,
+    handler: (changes: SuiClientTypes.ChangedObject[], ctx: SuiObjectChangeContext) => PromiseOrVoid,
     type: string | string[]
   ): this {
     if (this.config.network === SuiNetwork.TEST_NET) {
@@ -299,7 +299,10 @@ export class SuiBaseProcessor {
           data.txDigest,
           processor.config.baseLabels
         )
-        await handler(data.rawChanges.map((r) => JSON.parse(r)) as SuiObjectChange[], ctx)
+        await handler(
+          data.rawChanges.map((r) => toSuiClientChangedObject(JSON.parse(r))),
+          ctx
+        )
         return ctx.stopAndGetResult()
       },
       type
@@ -333,7 +336,7 @@ export class SuiGlobalProcessor extends SuiBaseProcessor {
 
   // deprecated,, use object type processor
   public onObjectChange(
-    handler: (changes: SuiObjectChange[], ctx: SuiObjectChangeContext) => void,
+    handler: (changes: SuiClientTypes.ChangedObject[], ctx: SuiObjectChangeContext) => void,
     type: string | string[]
   ): this {
     return super.onObjectChange(handler, type)

--- a/packages/sdk/src/sui/tests/to-client-types.test.ts
+++ b/packages/sdk/src/sui/tests/to-client-types.test.ts
@@ -4,7 +4,7 @@ import { defaultMoveCoder } from '../move-coder.js'
 import { loadAllTypes } from '../builtin/0x2.js'
 import { SuiNetwork } from '../network.js'
 import { parseMoveType } from '../../move/index.js'
-import { toSuiClientObject } from '../to-client-types.js'
+import { toSuiClientChangedObject, toSuiClientObject } from '../to-client-types.js'
 
 // Raw protojson of a `sui.rpc.v2.Object` exactly as the Sentio driver emits it
 // (BatchGetObjects -> protojson.Marshal): note `objectType` / `owner.kind` /
@@ -67,5 +67,60 @@ describe('toSuiClientObject', () => {
     expect(d.id.id).equals(grpcObject.json.id)
     expect(d.name.name).equals(grpcObject.json.name.name) // Wrapper<address>{ name }
     expect(d.value).equals(grpcObject.json.value) // ID -> string
+  })
+})
+
+// Raw protojson of a `sui.rpc.v2.ChangedObject` as the Sentio driver emits it
+// from transaction effects: proto enum *value names* (`OUTPUT_OBJECT_STATE_*`,
+// `CREATED`), uint64 versions as strings, and `Owner` in its gRPC `{kind}` shape.
+const grpcMutatedChange = {
+  objectId: '0xc061d544681939544136efac81d212de377e2ff13eb07ef9079404ebd57cad5d',
+  inputState: 'INPUT_OBJECT_STATE_EXISTS',
+  inputVersion: '309855313',
+  inputDigest: 'AAA',
+  inputOwner: { kind: 'ADDRESS', address: '0x1' },
+  outputState: 'OUTPUT_OBJECT_STATE_OBJECT_WRITE',
+  outputVersion: '309855314',
+  outputDigest: 'BBB',
+  outputOwner: { kind: 'SHARED', version: '7' },
+  idOperation: 'NONE',
+  objectType: '0x2::coin::Coin<0x2::sui::SUI>' // present on gRPC, absent on unified
+}
+
+describe('toSuiClientChangedObject', () => {
+  test('maps gRPC protojson ChangedObject to unified SuiClientTypes shape', () => {
+    const c = toSuiClientChangedObject(grpcMutatedChange) as any
+    expect(c.objectId).equals(grpcMutatedChange.objectId)
+    expect(c.inputState).equals('Exists')
+    expect(c.outputState).equals('ObjectWrite')
+    expect(c.idOperation).equals('None')
+    expect(c.inputVersion).equals('309855313') // uint64 string preserved
+    expect(c.outputVersion).equals('309855314')
+    expect(c.inputDigest).equals('AAA')
+    expect(c.outputDigest).equals('BBB')
+    expect(c.inputOwner).deep.equals({ $kind: 'AddressOwner', AddressOwner: '0x1' })
+    expect(c.outputOwner).deep.equals({ $kind: 'Shared', Shared: { initialSharedVersion: '7' } })
+    expect('objectType' in c).equals(false) // dropped: not on the unified type
+  })
+
+  test('all enum value names map to the unified literals', () => {
+    const states = (s: any) => toSuiClientChangedObject(s) as any
+    expect(states({ inputState: 'INPUT_OBJECT_STATE_DOES_NOT_EXIST' }).inputState).equals('DoesNotExist')
+    expect(states({ outputState: 'OUTPUT_OBJECT_STATE_PACKAGE_WRITE' }).outputState).equals('PackageWrite')
+    expect(states({ outputState: 'OUTPUT_OBJECT_STATE_DOES_NOT_EXIST' }).outputState).equals('DoesNotExist')
+    expect(states({ outputState: 'OUTPUT_OBJECT_STATE_ACCUMULATOR_WRITE' }).outputState).equals('AccumulatorWriteV1')
+    expect(states({ idOperation: 'CREATED' }).idOperation).equals('Created')
+    expect(states({ idOperation: 'DELETED' }).idOperation).equals('Deleted')
+    expect(states({ idOperation: 'ID_OPERATION_UNKNOWN' }).idOperation).equals('None')
+  })
+
+  test('absent enum/owner fields fall back to Unknown / null', () => {
+    const c = toSuiClientChangedObject({ objectId: '0x9' }) as any
+    expect(c.inputState).equals('Unknown')
+    expect(c.outputState).equals('Unknown')
+    expect(c.idOperation).equals('Unknown')
+    expect(c.inputVersion).equals(null)
+    expect(c.inputOwner).equals(null)
+    expect(c.outputOwner).equals(null)
   })
 })

--- a/packages/sdk/src/sui/to-client-types.ts
+++ b/packages/sdk/src/sui/to-client-types.ts
@@ -17,6 +17,7 @@ function base64ToBytes(b64: string): Uint8Array {
 
 // Mirrors mapOwner in @mysten/sui's grpc core. protojson serializes the
 // Owner.OwnerKind enum to its proto value name and uint64 `version` to a string.
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L821
 function mapOwner(owner: any): SuiClientTypes.ObjectOwner | null {
   if (!owner) {
     return null
@@ -45,6 +46,7 @@ function mapOwner(owner: any): SuiClientTypes.ObjectOwner | null {
 // `.json` are read with the gRPC names falling back to the unified ones. With
 // `Include = { json: true }` every field except objectId/version/digest/owner/
 // type/json is typed `undefined`, so we deliberately leave them unset.
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L176
 export function toSuiClientObject(o: any): SuiMoveObjectInput {
   return {
     objectId: o.objectId,
@@ -60,9 +62,78 @@ export function toSuiClientObject(o: any): SuiMoveObjectInput {
   } as SuiMoveObjectInput
 }
 
+// Enum mapping mirrors @mysten/sui's grpc core (parseTransactionEffects), but
+// reads protojson enum *value names* (the Sentio driver delivers protojson, so
+// enums arrive as their proto names, not protobuf-es numeric values). Absent
+// fields map to 'Unknown' to honor the non-nullable `SuiClientTypes.ChangedObject`
+// state types.
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1065
+function mapInputObjectState(state: any): SuiClientTypes.ChangedObject['inputState'] {
+  switch (state) {
+    case 'INPUT_OBJECT_STATE_EXISTS':
+      return 'Exists'
+    case 'INPUT_OBJECT_STATE_DOES_NOT_EXIST':
+      return 'DoesNotExist'
+    default:
+      return 'Unknown'
+  }
+}
+
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1084
+function mapOutputObjectState(state: any): SuiClientTypes.ChangedObject['outputState'] {
+  switch (state) {
+    case 'OUTPUT_OBJECT_STATE_OBJECT_WRITE':
+      return 'ObjectWrite'
+    case 'OUTPUT_OBJECT_STATE_PACKAGE_WRITE':
+      return 'PackageWrite'
+    case 'OUTPUT_OBJECT_STATE_DOES_NOT_EXIST':
+      return 'DoesNotExist'
+    case 'OUTPUT_OBJECT_STATE_ACCUMULATOR_WRITE':
+      return 'AccumulatorWriteV1'
+    default:
+      return 'Unknown'
+  }
+}
+
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1045
+function mapIdOperation(operation: any): SuiClientTypes.ChangedObject['idOperation'] {
+  switch (operation) {
+    case 'CREATED':
+      return 'Created'
+    case 'DELETED':
+      return 'Deleted'
+    case 'NONE':
+    case 'ID_OPERATION_UNKNOWN':
+      return 'None'
+    default:
+      return 'Unknown'
+  }
+}
+
+// protojson `sui.rpc.v2.ChangedObject` -> unified `SuiClientTypes.ChangedObject`.
+// Mirrors the per-change mapping in @mysten/sui's grpc core so handlers see the
+// same shape `SuiGrpcClient.core` would produce. `objectType`/`accumulatorWrite`
+// exist on the gRPC message but not the unified type, so they are dropped.
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1141
+export function toSuiClientChangedObject(c: any): SuiClientTypes.ChangedObject {
+  return {
+    objectId: c.objectId,
+    inputState: mapInputObjectState(c.inputState),
+    inputVersion: c.inputVersion ?? null,
+    inputDigest: c.inputDigest ?? null,
+    inputOwner: mapOwner(c.inputOwner),
+    outputState: mapOutputObjectState(c.outputState),
+    outputVersion: c.outputVersion ?? null,
+    outputDigest: c.outputDigest ?? null,
+    outputOwner: mapOwner(c.outputOwner),
+    idOperation: mapIdOperation(c.idOperation)
+  }
+}
+
 // protojson `sui.rpc.v2.Event` -> unified `SuiClientTypes.Event`. The
 // discriminating fields (`eventType`, `json`) already share names; only the
 // BCS payload is renamed (`contents` -> `bcs`).
+// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1279
 export function toSuiClientEvent(e: any): SuiEventInput {
   return {
     packageId: e.packageId,


### PR DESCRIPTION
## What

The `onObjectChange` handlers on `SuiBaseProcessor` / `SuiGlobalProcessor` / object-type processors were the last Sui processor surface still typed against `@mysten/sui/jsonRpc` (`SuiObjectChange`), left over from the JSON-RPC → gRPC migration. This switches the public callback type to the transport-agnostic **`SuiClientTypes.ChangedObject`** (`@mysten/sui/client`), consistent with how decoded events/objects are already typed in this package.

## Why normalization is needed

The Sentio driver delivers `raw_changes` as **protojson of the gRPC `ChangedObject` message** — enum *value-names* (`OUTPUT_OBJECT_STATE_OBJECT_WRITE`), uint64 versions as strings, and `Owner` in its gRPC `{kind}` shape. That does **not** structurally match the unified type, so a bare `JSON.parse(r) as SuiClientTypes.ChangedObject` would be a runtime lie.

New `toSuiClientChangedObject` normalizes at the SDK boundary — mirroring `@mysten/sui`'s grpc-core `parseTransactionEffects` per-change mapping (enum names → unified literals, `mapOwner` for input/output owners, dropping `objectType`/`accumulatorWrite` which aren't on the unified type). This is exactly the pattern the existing `toSuiClientObject`/`toSuiClientEvent`/`mapOwner` already follow. Each mirror helper carries a pinned source permalink to the upstream implementation.

## Changes

- `to-client-types.ts` — add `toSuiClientChangedObject` + `mapInputObjectState`/`mapOutputObjectState`/`mapIdOperation`; source-link comments on all mirror helpers
- `sui-processor.ts` / `sui-object-processor.ts` — handler callbacks now take `SuiClientTypes.ChangedObject[]`; parse via the normalizer; drop the `@mysten/sui/jsonRpc` import
- `tests/to-client-types.test.ts` — coverage for the enum/owner mapping and absent-field fallbacks

## Notes / follow-ups

- **Confirm before merge:** that `raw_changes` is serialized from the gRPC `ChangedObject` proto (same assumption that makes the already-merged `rawTransaction` → `GrpcTypes.ExecutedTransaction` correct).
- The mirror helpers track `@mysten/sui`'s **unexported** mapping; permalinks are pinned to a commit SHA (2.17.0 isn't tagged upstream yet). If the driver ever switches to emitting BCS effects, the official exported `parseTransactionEffectsBcs` could replace these entirely.
- IOTA still uses jsonRpc `IotaObjectChange` — intentionally left, since IOTA hasn't migrated to gRPC.

## Test

`npx tsx --test src/sui/tests/to-client-types.test.ts` — 6/6 pass; full `packages/sdk` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)