### PR TITLE
fix(sui): send chain-config rpc headers (X-Forwarded-Host) to rpc-node

### DIFF
--- a/packages/runtime/src/chain-config.ts
+++ b/packages/runtime/src/chain-config.ts
@@ -1,6 +1,6 @@
 export interface RpcConfig {
   Url: string
-  Meta?: Record<string, string>
+  Headers?: Record<string, string>
 }
 
 export interface ChainConfig {

--- a/packages/runtime/src/endpoints.ts
+++ b/packages/runtime/src/endpoints.ts
@@ -3,13 +3,13 @@ import fs from 'fs-extra'
 import { ChainConfig } from './chain-config.js'
 
 /**
- * Resolved RPC endpoint for a chain: the base URL plus optional gRPC metadata
- * (key-value pairs) attached to every request, e.g. the `authority` routing key
- * for the Sui gRPC client talking to the Sentio rpc-node.
+ * Resolved RPC endpoint for a chain: the base URL plus optional HTTP headers
+ * attached to every request, e.g. the `X-Forwarded-Host` routing key for the Sui
+ * gRPC client talking to the Sentio rpc-node.
  */
 export interface ChainRpc {
   url: string
-  meta?: Record<string, string>
+  headers?: Record<string, string>
 }
 
 export class Endpoints {
@@ -48,7 +48,7 @@ export function configureEndpoints(options: any) {
     if (chainConfig.Rpc?.Url) {
       Endpoints.INSTANCE.chainRpc.set(id, {
         url: chainConfig.Rpc.Url,
-        meta: chainConfig.Rpc.Meta
+        headers: chainConfig.Rpc.Headers
       })
     } else {
       const http = chainConfig.Https?.[0]

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -95,6 +95,7 @@
     "@iota/iota-sdk": "~1.14.0",
     "@mysten/sui": "~2.17.0",
     "@prettier/sync": "^0.6.0",
+    "@protobuf-ts/grpcweb-transport": "^2.11.1",
     "@sentio/api": "1.0.2",
     "@sentio/bigdecimal": "9.1.1-patch.3",
     "@sentio/chain": "~3.4.29",

--- a/packages/sdk/src/sui/network.ts
+++ b/packages/sdk/src/sui/network.ts
@@ -1,6 +1,7 @@
 import { SuiChainId } from '@sentio/chain'
 import { ChainRpc, Endpoints } from '@sentio/runtime'
 import { SuiGrpcClient } from '@mysten/sui/grpc'
+import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport'
 
 export type SuiNetwork = SuiChainId
 export const SuiNetwork = <const>{
@@ -23,13 +24,13 @@ function rpcFor(network: SuiNetwork): ChainRpc {
 // gRPC client used for the MoveCoder, generated view functions, and exposed to
 // processor handlers via `ctx.client`. @typemove/sui v2 is gRPC-only.
 export function getClient(network: SuiNetwork): SuiGrpcClient {
-  const { url, meta } = rpcFor(network)
-  return new SuiGrpcClient({
-    network: inferNetworkFromUrl(url) as any,
-    baseUrl: url,
-    // Metadata from the chain config (e.g. the authority routing key) is sent on every gRPC-web request.
-    meta
-  })
+  const { url, headers } = rpcFor(network)
+  // Headers from the chain config (e.g. the X-Forwarded-Host routing key the
+  // rpc-node proxy reads) must be sent on every gRPC-web request. SuiGrpcClient
+  // drops its `meta` option and its `fetchInit` can't carry headers, so build the
+  // transport ourselves with default `meta` (grpc-web sends it as request headers).
+  const transport = new GrpcWebFetchTransport({ baseUrl: url, meta: headers })
+  return new SuiGrpcClient({ network: inferNetworkFromUrl(url) as any, transport })
 }
 
 export function getRpcEndpoint(network: SuiNetwork): string {

--- a/packages/sdk/src/sui/network.ts
+++ b/packages/sdk/src/sui/network.ts
@@ -25,11 +25,17 @@ function rpcFor(network: SuiNetwork): ChainRpc {
 // processor handlers via `ctx.client`. @typemove/sui v2 is gRPC-only.
 export function getClient(network: SuiNetwork): SuiGrpcClient {
   const { url, headers } = rpcFor(network)
-  // Headers from the chain config (e.g. the X-Forwarded-Host routing key the
-  // rpc-node proxy reads) must be sent on every gRPC-web request. SuiGrpcClient
-  // drops its `meta` option and its `fetchInit` can't carry headers, so build the
-  // transport ourselves with default `meta` (grpc-web sends it as request headers).
-  const transport = new GrpcWebFetchTransport({ baseUrl: url, meta: headers })
+  // Chain-config headers (e.g. the X-Forwarded-Host routing key the rpc-node
+  // proxy reads) must be sent on every request. SuiGrpcClient drops its `meta`
+  // option and its `fetchInit` can't carry headers, so we build the transport
+  // ourselves.
+  const transport = new GrpcWebFetchTransport({
+    baseUrl: url,
+    // GrpcWebFetchTransport has no `headers` option: gRPC models per-request
+    // headers as `meta` (metadata), which the grpc-web transport then serializes
+    // as HTTP request headers on the wire. So our HTTP headers go in `meta`.
+    meta: headers
+  })
   return new SuiGrpcClient({ network: inferNetworkFromUrl(url) as any, transport })
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
       '@prettier/sync':
         specifier: ^0.6.0
         version: 0.6.1(prettier@3.5.3)
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
       '@sentio/api':
         specifier: 1.0.2
         version: 1.0.2


### PR DESCRIPTION
## Problem

`ctx.client` (the Sui gRPC client) routes internal processor requests through the rpc-node proxy, which identifies the processor from the request **Host / X-Forwarded-Host** in the form `<processorID>-<code>-<chainSlug>`. The driver already provides this routing key in the chain config, but it never reached the wire, so every request hit the rpc-node with Host `test-rpcnode-server.test` → the proxy parsed `processorID=test` → `Unauthenticated: invalid code for processor test`, and all `ctx.client` reads (coin metadata / pool / price) failed.

Root cause in the SDK: `getClient` passed the routing key as `SuiGrpcClient`'s `meta` option, but @mysten's `SuiGrpcClient` constructor only forwards `{baseUrl, fetchInit}` to its transport and **drops `meta`**; and `fetchInit`'s type forbids `headers`.

## Change

- Build the `GrpcWebFetchTransport` ourselves with the chain-config headers as default `meta` (grpc-web sends metadata as HTTP request headers) and pass it via the `transport` option that `SuiGrpcClient` does honor.
- Rename the chain-config rpc field from `meta` / `authority` to a generic `headers` map (`ChainRpc.headers`, `RpcConfig.Headers`), so the value — now `X-Forwarded-Host` — is just passed through verbatim. Future routing headers need no SDK change.

Added `@protobuf-ts/grpcweb-transport@^2.11.1` as a direct dep of `packages/sdk` (the version @mysten/sui already resolves, to avoid a duplicate copy).

## Verification

- `tsc` passes on the changed files (`network.ts`, `endpoints.ts`, `chain-config.ts`).
- Lockfile change is just the new importer entry.

## Paired sentio change

The driver emits `Rpc.Headers["X-Forwarded-Host"] = "<processorID>-<code>-<chainSlug>"`: https://github.com/sentioxyz/sentio/pull/18558. Both must deploy for `ctx.client` to authenticate; until then it falls back to the (already-broken) behavior, no regression.