### PR TITLE
refactor(sui): reuse @mysten/sui parseTransactionEffects instead of mirroring it

### DIFF
--- a/packages/sdk/src/sui/sui-object-processor.ts
+++ b/packages/sdk/src/sui/sui-object-processor.ts
@@ -25,7 +25,7 @@ import { CallHandler, TransactionFilter, accountTypeString, ObjectChangeHandler 
 import { ConnectError, Code } from '@connectrpc/connect'
 import { TypeDescriptor } from '@typemove/move'
 import { TypedSuiMoveObject } from './models.js'
-import { toSuiClientChangedObjects, toSuiClientObject } from './to-client-types.js'
+import { toSuiClientChangedObjects, toSuiClientObjects } from './to-client-types.js'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 
 export interface SuiObjectBindOptions {
@@ -191,10 +191,7 @@ export class SuiAddressProcessor extends SuiBaseObjectOrAddressProcessorInternal
     data: Data_SuiObject,
     ctx: SuiObjectContext
   ) {
-    return handler(
-      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
-      ctx
-    )
+    return handler(await toSuiClientObjects(data.rawObjects.map((o) => JSON.parse(o))), ctx)
   }
 
   onTransactionBlock(
@@ -271,8 +268,8 @@ export class SuiObjectProcessor extends SuiBaseObjectOrAddressProcessorInternal<
       return
     }
     return handler(
-      toSuiClientObject(JSON.parse(data.rawSelf)),
-      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
+      (await toSuiClientObjects([JSON.parse(data.rawSelf)]))[0],
+      await toSuiClientObjects(data.rawObjects.map((o) => JSON.parse(o))),
       ctx
     )
   }
@@ -310,13 +307,9 @@ export class SuiObjectTypeProcessor<T> extends SuiBaseObjectOrAddressProcessor<
       return
     }
     const object = await ctx.coder.filterAndDecodeObjects(this.objectType, [
-      toSuiClientObject(JSON.parse(data.rawSelf))
+      (await toSuiClientObjects([JSON.parse(data.rawSelf)]))[0]
     ])
-    return handler(
-      object[0],
-      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
-      ctx
-    )
+    return handler(object[0], await toSuiClientObjects(data.rawObjects.map((o) => JSON.parse(o))), ctx)
   }
 
   public onObjectChange(
@@ -410,9 +403,6 @@ export class SuiWrappedObjectProcessor extends SuiBaseObjectOrAddressProcessorIn
     data: Data_SuiObject,
     ctx: SuiObjectContext
   ) {
-    return handler(
-      data.rawObjects.map((o) => toSuiClientObject(JSON.parse(o))),
-      ctx
-    )
+    return handler(await toSuiClientObjects(data.rawObjects.map((o) => JSON.parse(o))), ctx)
   }
 }

--- a/packages/sdk/src/sui/sui-object-processor.ts
+++ b/packages/sdk/src/sui/sui-object-processor.ts
@@ -25,7 +25,7 @@ import { CallHandler, TransactionFilter, accountTypeString, ObjectChangeHandler 
 import { ConnectError, Code } from '@connectrpc/connect'
 import { TypeDescriptor } from '@typemove/move'
 import { TypedSuiMoveObject } from './models.js'
-import { toSuiClientChangedObject, toSuiClientObject } from './to-client-types.js'
+import { toSuiClientChangedObjects, toSuiClientObject } from './to-client-types.js'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 
 export interface SuiObjectBindOptions {
@@ -337,10 +337,7 @@ export class SuiObjectTypeProcessor<T> extends SuiBaseObjectOrAddressProcessor<
           data.txDigest,
           processor.config.baseLabels
         )
-        await handler(
-          data.rawChanges.map((r) => toSuiClientChangedObject(JSON.parse(r))),
-          ctx
-        )
+        await handler(await toSuiClientChangedObjects(data.rawChanges.map((r) => JSON.parse(r))), ctx)
         return ctx.stopAndGetResult()
       },
       type: [this.objectType.getSignature()]

--- a/packages/sdk/src/sui/sui-processor.ts
+++ b/packages/sdk/src/sui/sui-processor.ts
@@ -30,7 +30,7 @@ import { ALL_ADDRESS, Labels, PromiseOrVoid } from '../core/index.js'
 import { Required } from 'utility-types'
 import { getHandlerName, proxyProcessor } from '../utils/metrics.js'
 import { HandlerOptions } from './models.js'
-import { toSuiClientChangedObject, toSuiClientEvent } from './to-client-types.js'
+import { toSuiClientChangedObjects, toSuiClientEvent } from './to-client-types.js'
 
 export const DEFAULT_FETCH_CONFIG: MoveFetchConfig = create(MoveFetchConfigSchema, {
   resourceChanges: false,
@@ -299,10 +299,7 @@ export class SuiBaseProcessor {
           data.txDigest,
           processor.config.baseLabels
         )
-        await handler(
-          data.rawChanges.map((r) => toSuiClientChangedObject(JSON.parse(r))),
-          ctx
-        )
+        await handler(await toSuiClientChangedObjects(data.rawChanges.map((r) => JSON.parse(r))), ctx)
         return ctx.stopAndGetResult()
       },
       type

--- a/packages/sdk/src/sui/tests/to-client-types.test.ts
+++ b/packages/sdk/src/sui/tests/to-client-types.test.ts
@@ -4,7 +4,7 @@ import { defaultMoveCoder } from '../move-coder.js'
 import { loadAllTypes } from '../builtin/0x2.js'
 import { SuiNetwork } from '../network.js'
 import { parseMoveType } from '../../move/index.js'
-import { toSuiClientChangedObject, toSuiClientObject } from '../to-client-types.js'
+import { toSuiClientChangedObjects, toSuiClientObject } from '../to-client-types.js'
 
 // Raw protojson of a `sui.rpc.v2.Object` exactly as the Sentio driver emits it
 // (BatchGetObjects -> protojson.Marshal): note `objectType` / `owner.kind` /
@@ -87,9 +87,13 @@ const grpcMutatedChange = {
   objectType: '0x2::coin::Coin<0x2::sui::SUI>' // present on gRPC, absent on unified
 }
 
-describe('toSuiClientChangedObject', () => {
-  test('maps gRPC protojson ChangedObject to unified SuiClientTypes shape', () => {
-    const c = toSuiClientChangedObject(grpcMutatedChange) as any
+// These run the real @mysten/sui `parseTransactionEffects` (via the fake-client
+// in `toSuiClientChangedObjects`), so they double as a conformance guard: an
+// upgrade that changes the upstream mapping — or the internals the fake-client
+// leans on (`status.error` deref, the `{ $kind }` return union) — fails here.
+describe('toSuiClientChangedObjects', () => {
+  test('maps gRPC protojson ChangedObject to unified SuiClientTypes shape', async () => {
+    const [c] = (await toSuiClientChangedObjects([grpcMutatedChange])) as any[]
     expect(c.objectId).equals(grpcMutatedChange.objectId)
     expect(c.inputState).equals('Exists')
     expect(c.outputState).equals('ObjectWrite')
@@ -103,24 +107,29 @@ describe('toSuiClientChangedObject', () => {
     expect('objectType' in c).equals(false) // dropped: not on the unified type
   })
 
-  test('all enum value names map to the unified literals', () => {
-    const states = (s: any) => toSuiClientChangedObject(s) as any
-    expect(states({ inputState: 'INPUT_OBJECT_STATE_DOES_NOT_EXIST' }).inputState).equals('DoesNotExist')
-    expect(states({ outputState: 'OUTPUT_OBJECT_STATE_PACKAGE_WRITE' }).outputState).equals('PackageWrite')
-    expect(states({ outputState: 'OUTPUT_OBJECT_STATE_DOES_NOT_EXIST' }).outputState).equals('DoesNotExist')
-    expect(states({ outputState: 'OUTPUT_OBJECT_STATE_ACCUMULATOR_WRITE' }).outputState).equals('AccumulatorWriteV1')
-    expect(states({ idOperation: 'CREATED' }).idOperation).equals('Created')
-    expect(states({ idOperation: 'DELETED' }).idOperation).equals('Deleted')
-    expect(states({ idOperation: 'ID_OPERATION_UNKNOWN' }).idOperation).equals('None')
+  test('all enum value names map to the unified literals', async () => {
+    const one = async (s: any) => ((await toSuiClientChangedObjects([s])) as any[])[0]
+    expect((await one({ inputState: 'INPUT_OBJECT_STATE_DOES_NOT_EXIST' })).inputState).equals('DoesNotExist')
+    expect((await one({ outputState: 'OUTPUT_OBJECT_STATE_PACKAGE_WRITE' })).outputState).equals('PackageWrite')
+    expect((await one({ outputState: 'OUTPUT_OBJECT_STATE_DOES_NOT_EXIST' })).outputState).equals('DoesNotExist')
+    expect((await one({ outputState: 'OUTPUT_OBJECT_STATE_ACCUMULATOR_WRITE' })).outputState).equals(
+      'AccumulatorWriteV1'
+    )
+    expect((await one({ idOperation: 'CREATED' })).idOperation).equals('Created')
+    expect((await one({ idOperation: 'DELETED' })).idOperation).equals('Deleted')
+    expect((await one({ idOperation: 'ID_OPERATION_UNKNOWN' })).idOperation).equals('None')
   })
 
-  test('absent enum/owner fields fall back to Unknown / null', () => {
-    const c = toSuiClientChangedObject({ objectId: '0x9' }) as any
-    expect(c.inputState).equals('Unknown')
-    expect(c.outputState).equals('Unknown')
-    expect(c.idOperation).equals('Unknown')
+  // Upstream maps absent enum/owner fields to null (not 'Unknown'); the empty
+  // input short-circuits before constructing the fake client.
+  test('absent enum/owner fields become null; empty input yields []', async () => {
+    const [c] = (await toSuiClientChangedObjects([{ objectId: '0x9' }])) as any[]
+    expect(c.inputState).equals(null)
+    expect(c.outputState).equals(null)
+    expect(c.idOperation).equals(null)
     expect(c.inputVersion).equals(null)
     expect(c.inputOwner).equals(null)
     expect(c.outputOwner).equals(null)
+    expect(await toSuiClientChangedObjects([])).deep.equals([])
   })
 })

--- a/packages/sdk/src/sui/tests/to-client-types.test.ts
+++ b/packages/sdk/src/sui/tests/to-client-types.test.ts
@@ -4,7 +4,7 @@ import { defaultMoveCoder } from '../move-coder.js'
 import { loadAllTypes } from '../builtin/0x2.js'
 import { SuiNetwork } from '../network.js'
 import { parseMoveType } from '../../move/index.js'
-import { toSuiClientChangedObjects, toSuiClientObject } from '../to-client-types.js'
+import { toSuiClientChangedObjects, toSuiClientObjects } from '../to-client-types.js'
 
 // Raw protojson of a `sui.rpc.v2.Object` exactly as the Sentio driver emits it
 // (BatchGetObjects -> protojson.Marshal): note `objectType` / `owner.kind` /
@@ -25,10 +25,14 @@ const grpcObject = {
   }
 }
 
-describe('toSuiClientObject', () => {
-  test('maps gRPC protojson Object to unified SuiClientTypes shape', () => {
-    const o = toSuiClientObject(grpcObject) as any
-    expect(o.type).equals(grpcObject.objectType) // objectType -> type
+// Runs the real @mysten/sui `getObjects` mapping via the fake-client, so it also
+// guards the object/owner mapping against upstream drift.
+describe('toSuiClientObjects', () => {
+  const one = async (o: any) => ((await toSuiClientObjects([o])) as any[])[0]
+
+  test('maps gRPC protojson Object to unified SuiClientTypes shape', async () => {
+    const o = await one(grpcObject)
+    expect(o.type).equals(grpcObject.objectType) // objectType -> type (already normalized)
     expect(o.objectId).equals(grpcObject.objectId)
     expect(o.version).equals(grpcObject.version)
     expect(o.owner.$kind).equals('ObjectOwner') // {kind:'OBJECT'} -> ObjectOwner
@@ -36,16 +40,16 @@ describe('toSuiClientObject', () => {
     expect(o.json).deep.equals(grpcObject.json)
   })
 
-  test('owner kinds map to the unified union', () => {
-    expect((toSuiClientObject({ owner: { kind: 'ADDRESS', address: '0x1' } }) as any).owner).deep.equals({
+  test('owner kinds map to the unified union', async () => {
+    expect((await one({ objectId: '0x1', owner: { kind: 'ADDRESS', address: '0x1' } })).owner).deep.equals({
       $kind: 'AddressOwner',
       AddressOwner: '0x1'
     })
-    expect((toSuiClientObject({ owner: { kind: 'IMMUTABLE' } }) as any).owner).deep.equals({
+    expect((await one({ objectId: '0x2', owner: { kind: 'IMMUTABLE' } })).owner).deep.equals({
       $kind: 'Immutable',
       Immutable: true
     })
-    expect((toSuiClientObject({ owner: { kind: 'SHARED', version: '7' } }) as any).owner).deep.equals({
+    expect((await one({ objectId: '0x3', owner: { kind: 'SHARED', version: '7' } })).owner).deep.equals({
       $kind: 'Shared',
       Shared: { initialSharedVersion: '7' }
     })
@@ -61,7 +65,7 @@ describe('toSuiClientObject', () => {
     expect(rawDecoded.length).equals(0)
 
     // After normalization it matches and decodes the Move struct content.
-    const decoded = await coder.filterAndDecodeObjects(matcher, [toSuiClientObject(grpcObject)])
+    const decoded = await coder.filterAndDecodeObjects(matcher, await toSuiClientObjects([grpcObject]))
     expect(decoded.length).equals(1)
     const d = decoded[0].data_decoded as any
     expect(d.id.id).equals(grpcObject.json.id)

--- a/packages/sdk/src/sui/to-client-types.ts
+++ b/packages/sdk/src/sui/to-client-types.ts
@@ -1,4 +1,5 @@
 import type { SuiClientTypes } from '@mysten/sui/client'
+import { GrpcCoreClient, GrpcTypes } from '@mysten/sui/grpc'
 import type { SuiEventInput, SuiMoveObjectInput } from '@typemove/sui'
 
 // The Sentio driver delivers Sui objects/events as protojson of the gRPC
@@ -62,72 +63,34 @@ export function toSuiClientObject(o: any): SuiMoveObjectInput {
   } as SuiMoveObjectInput
 }
 
-// Enum mapping mirrors @mysten/sui's grpc core (parseTransactionEffects), but
-// reads protojson enum *value names* (the Sentio driver delivers protojson, so
-// enums arrive as their proto names, not protobuf-es numeric values). Absent
-// fields map to 'Unknown' to honor the non-nullable `SuiClientTypes.ChangedObject`
-// state types.
-// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1065
-function mapInputObjectState(state: any): SuiClientTypes.ChangedObject['inputState'] {
-  switch (state) {
-    case 'INPUT_OBJECT_STATE_EXISTS':
-      return 'Exists'
-    case 'INPUT_OBJECT_STATE_DOES_NOT_EXIST':
-      return 'DoesNotExist'
-    default:
-      return 'Unknown'
+// protojson `sui.rpc.v2.ChangedObject[]` -> unified `SuiClientTypes.ChangedObject[]`.
+//
+// Rather than mirror @mysten/sui's enum/owner mapping by hand, we reuse its own
+// `parseTransactionEffects` so SDK upgrades pick up upstream changes (new enum
+// values, owner kinds, bug fixes) automatically instead of silently drifting.
+// That function isn't exported, so we reach it through its only public caller,
+// `GrpcCoreClient.getTransaction`, fed by an in-memory fake transport that hands
+// back our changes as a protobuf-ts `TransactionEffects` message.
+//
+// Two upstream-internal details this depends on (both asserted by
+// to-client-types.test.ts, which fails loudly if an upgrade changes them):
+//   1. `parseTransactionEffects` dereferences `effects.status.error` unguarded on
+//      the non-success path, so a minimal `status: { success: true }` is required.
+//   2. `getTransaction` returns a `{ $kind: 'Transaction', Transaction }` union.
+// See https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1132
+export async function toSuiClientChangedObjects(rawChanges: any[]): Promise<SuiClientTypes.ChangedObject[]> {
+  if (rawChanges.length === 0) {
+    return []
   }
-}
-
-// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1084
-function mapOutputObjectState(state: any): SuiClientTypes.ChangedObject['outputState'] {
-  switch (state) {
-    case 'OUTPUT_OBJECT_STATE_OBJECT_WRITE':
-      return 'ObjectWrite'
-    case 'OUTPUT_OBJECT_STATE_PACKAGE_WRITE':
-      return 'PackageWrite'
-    case 'OUTPUT_OBJECT_STATE_DOES_NOT_EXIST':
-      return 'DoesNotExist'
-    case 'OUTPUT_OBJECT_STATE_ACCUMULATOR_WRITE':
-      return 'AccumulatorWriteV1'
-    default:
-      return 'Unknown'
-  }
-}
-
-// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1045
-function mapIdOperation(operation: any): SuiClientTypes.ChangedObject['idOperation'] {
-  switch (operation) {
-    case 'CREATED':
-      return 'Created'
-    case 'DELETED':
-      return 'Deleted'
-    case 'NONE':
-    case 'ID_OPERATION_UNKNOWN':
-      return 'None'
-    default:
-      return 'Unknown'
-  }
-}
-
-// protojson `sui.rpc.v2.ChangedObject` -> unified `SuiClientTypes.ChangedObject`.
-// Mirrors the per-change mapping in @mysten/sui's grpc core so handlers see the
-// same shape `SuiGrpcClient.core` would produce. `objectType`/`accumulatorWrite`
-// exist on the gRPC message but not the unified type, so they are dropped.
-// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L1141
-export function toSuiClientChangedObject(c: any): SuiClientTypes.ChangedObject {
-  return {
-    objectId: c.objectId,
-    inputState: mapInputObjectState(c.inputState),
-    inputVersion: c.inputVersion ?? null,
-    inputDigest: c.inputDigest ?? null,
-    inputOwner: mapOwner(c.inputOwner),
-    outputState: mapOutputObjectState(c.outputState),
-    outputVersion: c.outputVersion ?? null,
-    outputDigest: c.outputDigest ?? null,
-    outputOwner: mapOwner(c.outputOwner),
-    idOperation: mapIdOperation(c.idOperation)
-  }
+  const effects = GrpcTypes.TransactionEffects.fromJson(
+    { status: { success: true }, changedObjects: rawChanges },
+    { ignoreUnknownFields: true }
+  )
+  const core = new GrpcCoreClient({
+    client: { ledgerService: { getTransaction: async () => ({ response: { transaction: { digest: '', effects } } }) } }
+  } as any)
+  const res: any = await core.getTransaction({ digest: '', include: { effects: true } })
+  return (res.Transaction ?? res).effects.changedObjects
 }
 
 // protojson `sui.rpc.v2.Event` -> unified `SuiClientTypes.Event`. The

--- a/packages/sdk/src/sui/to-client-types.ts
+++ b/packages/sdk/src/sui/to-client-types.ts
@@ -16,51 +16,35 @@ function base64ToBytes(b64: string): Uint8Array {
   return new Uint8Array(Buffer.from(b64, 'base64'))
 }
 
-// Mirrors mapOwner in @mysten/sui's grpc core. protojson serializes the
-// Owner.OwnerKind enum to its proto value name and uint64 `version` to a string.
-// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L821
-function mapOwner(owner: any): SuiClientTypes.ObjectOwner | null {
-  if (!owner) {
-    return null
+// protojson `sui.rpc.v2.Object[]` -> unified `SuiClientTypes.Object<{ json: true }>[]`.
+//
+// Same reuse strategy as `toSuiClientChangedObjects`: instead of mirroring the
+// object/owner mapping by hand, drive @mysten/sui's own `getObjects` mapping
+// (which also normalizes the struct tag and owner) through a fake transport, so
+// SDK upgrades stay in lockstep. `getObjects` chunks ids by 50 and calls
+// `ledgerService.batchGetObjects` per chunk reading `{ result: { oneofKind } }`
+// per request, so the fake returns objects keyed by the requested id.
+// `include: { json: true }` leaves content/objectBcs/previousTransaction/display
+// unset, matching the old hand-rolled output.
+// See https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L176
+export async function toSuiClientObjects(rawObjects: any[]): Promise<SuiMoveObjectInput[]> {
+  if (rawObjects.length === 0) {
+    return []
   }
-  switch (owner.kind) {
-    case 'IMMUTABLE':
-      return { $kind: 'Immutable', Immutable: true }
-    case 'ADDRESS':
-      return { $kind: 'AddressOwner', AddressOwner: owner.address }
-    case 'OBJECT':
-      return { $kind: 'ObjectOwner', ObjectOwner: owner.address }
-    case 'SHARED':
-      return { $kind: 'Shared', Shared: { initialSharedVersion: String(owner.version) } }
-    case 'CONSENSUS_ADDRESS':
-      return {
-        $kind: 'ConsensusAddressOwner',
-        ConsensusAddressOwner: { startVersion: String(owner.version), owner: owner.address }
+  const byId = new Map(rawObjects.map((o) => [o.objectId, GrpcTypes.Object.fromJson(o, { ignoreUnknownFields: true })]))
+  const core = new GrpcCoreClient({
+    client: {
+      ledgerService: {
+        batchGetObjects: async ({ requests }: any) => ({
+          response: {
+            objects: requests.map((r: any) => ({ result: { oneofKind: 'object', object: byId.get(r.objectId) } }))
+          }
+        })
       }
-    default:
-      return { $kind: 'Unknown' }
-  }
-}
-
-// protojson `sui.rpc.v2.Object` -> unified `SuiClientTypes.Object<{ json: true }>`.
-// Already-unified inputs (from `SuiGrpcClient.core`) pass through: `.type` and
-// `.json` are read with the gRPC names falling back to the unified ones. With
-// `Include = { json: true }` every field except objectId/version/digest/owner/
-// type/json is typed `undefined`, so we deliberately leave them unset.
-// Source: https://github.com/MystenLabs/ts-sdks/blob/8588da38e0a813f87b345c348e63486a7a766a61/packages/sui/src/grpc/core.ts#L176
-export function toSuiClientObject(o: any): SuiMoveObjectInput {
-  return {
-    objectId: o.objectId,
-    version: o.version,
-    digest: o.digest,
-    owner: mapOwner(o.owner)!,
-    type: o.objectType ?? o.type ?? '',
-    content: undefined,
-    previousTransaction: undefined,
-    objectBcs: undefined,
-    json: o.json ?? null,
-    display: undefined
-  } as SuiMoveObjectInput
+    }
+  } as any)
+  const res: any = await core.getObjects({ objectIds: rawObjects.map((o) => o.objectId), include: { json: true } })
+  return res.objects as SuiMoveObjectInput[]
 }
 
 // protojson `sui.rpc.v2.ChangedObject[]` -> unified `SuiClientTypes.ChangedObject[]`.


### PR DESCRIPTION
Follow-up to #80. That PR mirrored `@mysten/sui`'s object-change enum/owner mapping by hand; this replaces the mirror with a thin wrapper that drives upstream's **own** `parseTransactionEffects`.

## Why

A hand-rolled mirror drifts **silently** on `@mysten/sui` upgrades — a new `OutputObjectState` value or an upstream bug-fix just wouldn't reach us, and fixed-fixture tests would still pass. Reusing upstream flips both halves: we pick up new enum values / owner kinds / fixes for free, and if upstream changes in a way we depend on, a test fails **loudly** at upgrade time instead of shipping wrong data.

## How

`parseTransactionEffects` isn't exported from the published package, so `toSuiClientChangedObjects` reaches it through its only public caller — `GrpcCoreClient.getTransaction` — fed by an in-memory **fake transport** that returns our changes as a protobuf-ts `TransactionEffects` message (`GrpcTypes.TransactionEffects.fromJson`). The function is async and batches a tx's changes in one call.

Two upstream-internal details it leans on (both pinned by tests, so an upgrade that breaks them fails CI):
1. `parseTransactionEffects` dereferences `effects.status.error` **unguarded** on the non-success path → we inject a minimal `status: { success: true }`.
2. `getTransaction` returns a `{ $kind: 'Transaction', Transaction }` union → we unwrap it.

## Behavior change vs #80

Upstream maps **absent** enum fields to `null` (not `'Unknown'` as the old mirror did). Tests updated to assert this.

## Trade-off (acknowledged)

This couples to `GrpcCoreClient`'s private transport/return contract — more fragile than the proto enum names the mirror used. The deliberate bet (see the discussion that led here): loud, test-surfaced breakage at upgrade time beats silent drift. `to-client-types.test.ts` runs the real upstream path, so it doubles as a conformance/drift guard.

Net: −34 lines, no hand-maintained mapping. The cleaner long-term endpoints remain `parseTransactionEffectsBcs` (if the driver emits effects BCS) or a future upstream re-export of `parseTransactionEffects` — either would drop the fake-client.

## Test

`npx tsx --test src/sui/tests/*.test.ts` — 25/25 pass; full `packages/sdk` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)