### PR TITLE
fix(sui): use binary grpc-web format for the gRPC client

### DIFF
--- a/packages/sdk/src/sui/network.ts
+++ b/packages/sdk/src/sui/network.ts
@@ -31,6 +31,11 @@ export function getClient(network: SuiNetwork): SuiGrpcClient {
   // ourselves.
   const transport = new GrpcWebFetchTransport({
     baseUrl: url,
+    // GrpcWebFetchTransport defaults to the grpc-web-text (base64) format, which
+    // our rpc-node/super-node proxy rejects with 415. We run under Node, whose
+    // fetch handles binary streams fine, so use the binary format
+    // (application/grpc-web+proto) the proxy supports.
+    format: 'binary',
     // GrpcWebFetchTransport has no `headers` option: gRPC models per-request
     // headers as `meta` (metadata), which the grpc-web transport then serializes
     // as HTTP request headers on the wire. So our HTTP headers go in `meta`.


### PR DESCRIPTION
## Problem

`getClient` builds its `SuiGrpcClient` on a `GrpcWebFetchTransport`, but never sets `format`. `@protobuf-ts/grpcweb-transport` **defaults `format` to `'text'`** (`grpc-web-transport`: `format = opt.format ?? 'text'`), so every request goes out as `application/grpc-web-text` (base64 over the whole body).

The rpc-node / super-node gRPC proxy (sentio-core's shared `GRPCProxyHandler`) only accepts binary grpc-web — `application/grpc-web(+proto)` — and rejects `application/grpc-web-text` with `415 Unsupported Media Type`. As a result every `ctx.client` gRPC read failed; e.g. a Sui SDK 4 processor logs `calculate fee error Unsupported Media Type` for each call.

## Change

Set `format: 'binary'` on the transport so requests use `application/grpc-web+proto`, which the proxy supports. The processor runs under Node, whose `fetch` handles binary streams, so the text format (a browser/XHR fallback) is unnecessary here.

## Verification

The proxy's binary grpc-web path was confirmed end-to-end against the deployed super node (`test/super-node-sui-grpc`): an `application/grpc-web+proto` `GetServiceInfo` returns an `application/grpc-web+proto` response with a valid message frame and an in-body `grpc-status: 0` trailer frame. This change makes the SDK use that same binary path.

`format: 'binary'` is a valid value of the transport option type (`format?: "text" | "binary"`); the construction site typechecks clean (the only error under a non-bootstrapped tree is the unrelated missing `@sentio/runtime` build output).