### PR TITLE
fix(store): guard Int/Int8 entity values against int32/int64 overflow

### DIFF
--- a/packages/sdk/src/store/convert.test.ts
+++ b/packages/sdk/src/store/convert.test.ts
@@ -1,5 +1,13 @@
 import { describe, it } from 'node:test'
-import { BigDecimalConverter, BigIntConverter, BytesConverter, StringConverter, ValueConverter } from './convert.js'
+import {
+  BigDecimalConverter,
+  BigIntConverter,
+  BytesConverter,
+  Int8Converter,
+  IntConverter,
+  StringConverter,
+  ValueConverter
+} from './convert.js'
 import { expect } from 'chai'
 import { BigDecimal } from '@sentio/bigdecimal'
 import { RichStructSchema } from '@sentio/protos'
@@ -23,6 +31,33 @@ describe('RichStruct converter tests', () => {
     expect(struct2.value.case === 'bigintValue' ? struct2.value.value.negative : undefined).eq(true)
     const s1 = BigIntConverter.to(struct)
     expect(s1).eq(s)
+  })
+
+  it('int converter', () => {
+    const struct = IntConverter.from(100)
+    expect(struct.value.case).eq('intValue')
+    expect(IntConverter.to(struct)).eq(100)
+    // floors non-integers
+    expect(IntConverter.to(IntConverter.from(1.9))).eq(1)
+  })
+
+  it('int converter rejects out-of-int32-range values', () => {
+    // 168131880000 overflows int32 and would otherwise fail later in the runtime
+    // with a cryptic "cannot encode field ...: invalid int32" serialize error.
+    expect(() => IntConverter.from(168131880000)).to.throw(/out of the int32 range/)
+    expect(() => IntConverter.from(2147483648)).to.throw(/out of the int32 range/)
+    expect(() => IntConverter.from(-2147483649)).to.throw(/out of the int32 range/)
+    // boundary values are accepted
+    expect(IntConverter.to(IntConverter.from(2147483647))).eq(2147483647)
+    expect(IntConverter.to(IntConverter.from(-2147483648))).eq(-2147483648)
+  })
+
+  it('int8 converter rejects out-of-int64-range values', () => {
+    expect(() => Int8Converter.from(9223372036854775808n)).to.throw(/out of the int64 range/)
+    expect(() => Int8Converter.from(-9223372036854775809n)).to.throw(/out of the int64 range/)
+    // boundary values are accepted
+    expect(Int8Converter.to(Int8Converter.from(9223372036854775807n))).eq(9223372036854775807n)
+    expect(Int8Converter.to(Int8Converter.from(-9223372036854775808n))).eq(-9223372036854775808n)
   })
 
   it('bigDecimal converter', () => {

--- a/packages/sdk/src/store/convert.ts
+++ b/packages/sdk/src/store/convert.ts
@@ -19,6 +19,15 @@ function nullRichValue(): RichValue {
   return create(RichValueSchema, { value: { case: 'nullValue', value: RichValue_NullValue.NULL_VALUE } })
 }
 
+// RichValue.int_value is an int32 and RichValue.int64_value is an int64 on the wire.
+// Values outside these ranges encode fine in memory but fail later in the runtime with a
+// cryptic "cannot encode field ...: invalid int32/int64" error during binary serialization.
+// Guard at the conversion site so the failure points at the offending field/value instead.
+const INT32_MIN = -2147483648
+const INT32_MAX = 2147483647
+const INT64_MIN = -9223372036854775808n
+const INT64_MAX = 9223372036854775807n
+
 export function required_<T>(converter: ValueConverter<T | undefined>): ValueConverter<T> {
   const { from, to, ...rest } = converter
   return {
@@ -121,7 +130,14 @@ export const IntConverter: ValueConverter<Int | undefined> = {
     if (value == null) {
       return nullRichValue()
     }
-    return create(RichValueSchema, { value: { case: 'intValue', value: Math.floor(value) } })
+    const i = Math.floor(value)
+    if (i < INT32_MIN || i > INT32_MAX) {
+      throw new Error(
+        `Int value ${i} is out of the int32 range [${INT32_MIN}, ${INT32_MAX}]. ` +
+          `Use BigInt (arbitrary precision) or Int8 (int64) for this field in your schema.`
+      )
+    }
+    return create(RichValueSchema, { value: { case: 'intValue', value: i } })
   },
   to(v) {
     return (v.value.case === 'intValue' ? v.value.value : undefined) as Int
@@ -133,7 +149,14 @@ export const Int8Converter: ValueConverter<bigint | undefined> = {
     if (value == null) {
       return nullRichValue()
     }
-    return create(RichValueSchema, { value: { case: 'int64Value', value: BigInt(value) } })
+    const i = BigInt(value)
+    if (i < INT64_MIN || i > INT64_MAX) {
+      throw new Error(
+        `Int8 value ${i} is out of the int64 range [${INT64_MIN}, ${INT64_MAX}]. ` +
+          `Use BigInt (arbitrary precision) for this field in your schema.`
+      )
+    }
+    return create(RichValueSchema, { value: { case: 'int64Value', value: i } })
   },
   to(v) {
     return v.value.case === 'int64Value' ? v.value.value : undefined


### PR DESCRIPTION
## Problem

A `sui/coins` processor writing an `Account` entity hit this cryptic runtime error:

```
serialize binary: cannot encode field common.RichValue.int_value to binary: invalid int32: 168131880000
```

Entity fields typed `Int` map to proto `RichValue.int_value`, which is an **int32** (max `2,147,483,647`). A value like a coin balance of `168131880000` (~168B) overflows it. Today `IntConverter.from` just `Math.floor`s the value with **no range check** — the bad `RichValue` is built happily in memory and only blows up later in the runtime's protobuf binary serializer, far from the call site, with no indication of which field is at fault.

This is fundamentally a runtime concern: `Int` is `type Int = number`, and TypeScript's `number` has no int32-range refinement, so `tsc` cannot catch it statically.

## Fix

Add a range check in `IntConverter` (int32) and `Int8Converter` (int64) that throws **at the write site** with an actionable message:

```
Int value 168131880000 is out of the int32 range [-2147483648, 2147483647].
Use BigInt (arbitrary precision) or Int8 (int64) for this field in your schema.
```

`BigInt` (→ `bigintValue`, arbitrary precision) is unaffected and remains the correct type for large amounts. Chose to **throw** rather than silently auto-promote, since an out-of-range `Int` is a schema-modeling mistake (the stored column type would otherwise change unexpectedly).

## Tests

Added cases in `convert.test.ts` covering the overflow (incl. the exact `168131880000` value), the int64 boundary, and that boundary values (`±int32`/`±int64` limits) are still accepted. All store converter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)