### PR TITLE
feat(cli): rename testnet-v2 to `testnet`; remove legacy testnet and devnet

### DIFF
--- a/packages/cli/src/commands/stop-processor.ts
+++ b/packages/cli/src/commands/stop-processor.ts
@@ -16,7 +16,7 @@ export function createStopProcessorCommand() {
   return new Command('stop')
     .description('Stop a processor. Uses Sentio Network contract when --sentio-network is specified.')
     .argument('<processorId>', 'ID of the processor to stop')
-    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet, testnet-v2 or devnet)')
+    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet)')
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -87,7 +87,7 @@ export function createUploadCommand() {
     .option('--num-workers <count>', '(Optional) Number of processor workers to start', myParseInt)
     .option(
       '--sentio-network <network>',
-      '(Optional) Sentio network to connect to, can be testnet, testnet-v2, devnet or mainnet'
+      '(Optional) Sentio network to connect to, can be testnet or mainnet'
     )
     .option(
       '--required-chain-id <chain_id...>',
@@ -95,7 +95,7 @@ export function createUploadCommand() {
     )
     .option(
       '--no-platform',
-      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Only testnet and devnet are supported.'
+      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Only testnet is supported.'
     )
     .option(
       '--ipfs-put-url <url>',
@@ -569,7 +569,7 @@ async function checkOrCreateProject(options: YamlProjectConfig, auth: Auth) {
     console.error(
       chalk.red(
         `Project ${project?.slug} is a Sentio Network project. Please add the --sentio-network flag when uploading.\n` +
-          `Example: sentio upload --sentio-network testnet|testnet-v2|devnet`
+          `Example: sentio upload --sentio-network testnet`
       )
     )
     process.exit(1)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,7 +34,7 @@ export interface YamlProjectConfig {
   silentOverwrite?: boolean
   variables?: Variable[]
   numWorkers?: number // Number of processor worker to start, default to 1
-  sentioNetwork?: string // Sentio network to connect to, can be testnet, testnet-v2, devnet or mainnet
+  sentioNetwork?: string // Sentio network to connect to, can be testnet or mainnet
   requiredChainIds?: string[]
 }
 
@@ -113,23 +113,16 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
         config.sentioNetwork = '789210'
         break
       case 'testnet':
-        config.sentioNetwork = '7892101'
-        break
-      case 'devnet':
-        config.sentioNetwork = '7892201'
-        break
       case 'testnet-v2':
         config.sentioNetwork = '7892102'
         break
-      case '7892101':
-      case '7892201':
       case '7892102':
       case '789210':
         config.sentioNetwork = options.sentioNetwork
         break
       default:
         console.error(
-          `Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet, testnet-v2 or devnet is allowed`
+          `Invalid sentio network: ${options.sentioNetwork}, only mainnet or testnet is allowed`
         )
         process.exit(1)
     }

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -13,43 +13,30 @@ interface SentioNetworkConfig {
   addressBookAddress: string
 }
 
+// Sentio Network testnet — chain id 7892102 (formerly exposed as `testnet-v2`).
+// The legacy testnet (7892101) and devnet have been removed; `testnet` is this
+// network. `testnet-v2` is still accepted as an alias.
 const TESTNET_CONFIG: SentioNetworkConfig = {
-  chainId: 7892101,
-  rpcUrl: 'https://sentio-testnet.rpc.sentio.xyz',
-  explorerUrl: 'https://testnet-explorer.sentio.xyz',
-  addressBookAddress: '0x092d795d42e23ecba5cc66927972be5c9980effb'
-}
-
-const TESTNET_V2_CONFIG: SentioNetworkConfig = {
   chainId: 7892102,
+  // v2 is the primary testnet: it owns the canonical testnet-explorer.sentio.xyz
+  // (v1 → testnet-v1-explorer). The chain RPC keeps its -v2 host for now.
   rpcUrl: 'https://sentio-testnet-v2.rpc.sentio.xyz',
-  explorerUrl: 'https://testnet-v2-explorer.sentio.xyz',
+  explorerUrl: 'https://testnet-explorer.sentio.xyz',
   addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
-}
-
-const DEVNET_CONFIG: SentioNetworkConfig = {
-  chainId: 7892201,
-  rpcUrl: 'https://sentio-devnet.test-rpc.sentio.xyz',
-  explorerUrl: 'https://devnet-explorer.sentio.xyz',
-  addressBookAddress: '0xCfCE965429602b02b453477Cd8Bc7FEd5E8ffc14'
 }
 
 export function getSentioNetworkConfig(network: string, addressBookOverride?: string): SentioNetworkConfig {
   let config: SentioNetworkConfig
-  if (network === 'testnet' || network === '7892101') {
+  if (network === 'testnet' || network === 'testnet-v2' || network === '7892102') {
     config = TESTNET_CONFIG
-  } else if (network === 'devnet' || network === '7892201') {
-    config = DEVNET_CONFIG
-  } else if (network === 'testnet-v2' || network === '7892102') {
-    config = TESTNET_V2_CONFIG
   } else if (network === 'mainnet' || network === '789210') {
     console.error(
-      chalk.red('Sentio Network mainnet is not yet supported. Only testnet, testnet-v2 and devnet are available.')
+      chalk.red('Sentio Network mainnet is not yet supported. Only testnet is available.')
     )
     process.exit(1)
   } else {
     console.error(
-      chalk.red(`Invalid sentio network: ${network}. Only "testnet", "testnet-v2" or "devnet" is supported.`)
+      chalk.red(`Invalid sentio network: ${network}. Only "testnet" is supported.`)
     )
     process.exit(1)
   }


### PR DESCRIPTION
## Summary

`--sentio-network testnet` now resolves to **chain 7892102** (formerly exposed as `testnet-v2`): rpc `sentio-testnet-v2.rpc.sentio.xyz`, explorer `testnet-v2-explorer.sentio.xyz`, AddressBook `0xb7e9E56DFC27bcfA63698F2F5890e186426A0123`. testnet-v2 is now *the* Sentio Network testnet (v1 deprecated), so users just pass `--sentio-network testnet`.

## Changes
- **`network.ts`** — the legacy testnet (`7892101`) and `devnet` (`7892201`) configs are removed; the sole `TESTNET_CONFIG` now holds the v2 values. `getSentioNetworkConfig` maps `testnet` / `testnet-v2` / `7892102` → it.
- **`config.ts`** — `--sentio-network` `testnet`/`testnet-v2` → `7892102`; the `devnet` and legacy-testnet cases are removed.
- **`upload.ts` / `stop-processor.ts`** — help text updated.

## Kept (not touched)
- **`testnet-v2`** and **`7892102`** are still accepted as aliases for the same network.
- **`mainnet`** is unchanged (still returns "not yet supported").

## ⚠️ Breaking
- `--sentio-network devnet` (and `7892201`) is removed → errors.
- `--sentio-network testnet` now points to `7892102` (was the retired legacy testnet `7892101`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
