### PR TITLE
fix(cli): re-download legacy Sui ABIs before codegen

### DIFF
--- a/packages/cli/src/abi.test.ts
+++ b/packages/cli/src/abi.test.ts
@@ -1,5 +1,8 @@
 import { describe, test } from 'node:test'
-import { getABI } from './abi.js'
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+import { getABI, collectLegacySuiAbis } from './abi.js'
 import { AptosChainId, EthChainId, SuiChainId } from '@sentio/chain'
 import { expect } from 'chai'
 
@@ -46,5 +49,87 @@ describe('Test ABI get', () => {
       undefined
     )
     expect(abi.abi !== undefined).eq(true)
+  })
+})
+
+describe('Test legacy Sui ABI collection', () => {
+  const legacyModuleMap = {
+    m1: {
+      fileFormatVersion: 6,
+      address: '0xpkg',
+      name: 'm1',
+      friends: [],
+      structs: {
+        S: { abilities: { abilities: ['Copy', 'Drop'] }, typeParameters: [], fields: [{ name: 'x', type: 'U64' }] }
+      },
+      exposedFunctions: {
+        f: { visibility: 'Public', isEntry: false, typeParameters: [], parameters: ['U64'], return: [] }
+      }
+    }
+  }
+  const newShapeAbi = [{ address: '0x111', module: { name: 'n', datatypes: [], functions: [] } }]
+
+  function makeDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sentio-sui-abi-'))
+    fs.mkdirSync(path.join(dir, 'testnet'), { recursive: true })
+    return dir
+  }
+
+  test('collects a legacy mainnet ABI with the address taken from its file name', () => {
+    const dir = makeDir()
+    try {
+      const file = path.join(dir, '0xabc.json')
+      fs.writeFileSync(file, JSON.stringify(legacyModuleMap))
+
+      const legacy = collectLegacySuiAbis(dir)
+
+      expect(legacy).length(1)
+      expect(legacy[0].file).eq(file)
+      expect(legacy[0].address).eq('0xabc')
+      expect(legacy[0].chain).eq(SuiChainId.SUI_MAINNET)
+    } finally {
+      fs.removeSync(dir)
+    }
+  })
+
+  test('marks files under testnet/ as SUI_TESTNET', () => {
+    const dir = makeDir()
+    try {
+      const file = path.join(dir, 'testnet', '0xdef.json')
+      fs.writeFileSync(file, JSON.stringify(legacyModuleMap))
+
+      const legacy = collectLegacySuiAbis(dir)
+
+      expect(legacy).length(1)
+      expect(legacy[0].chain).eq(SuiChainId.SUI_TESTNET)
+    } finally {
+      fs.removeSync(dir)
+    }
+  })
+
+  test('falls back to the module address for files saved under a custom name', () => {
+    const dir = makeDir()
+    try {
+      const file = path.join(dir, 'my-package.json')
+      fs.writeFileSync(file, JSON.stringify(legacyModuleMap))
+
+      const legacy = collectLegacySuiAbis(dir)
+
+      expect(legacy).length(1)
+      expect(legacy[0].address).eq('0xpkg')
+    } finally {
+      fs.removeSync(dir)
+    }
+  })
+
+  test('ignores already-migrated gRPC-shape files', () => {
+    const dir = makeDir()
+    try {
+      fs.writeFileSync(path.join(dir, '0x111.json'), JSON.stringify(newShapeAbi))
+
+      expect(collectLegacySuiAbis(dir)).length(0)
+    } finally {
+      fs.removeSync(dir)
+    }
   })
 })

--- a/packages/cli/src/abi.ts
+++ b/packages/cli/src/abi.ts
@@ -146,6 +146,120 @@ export function normalizedModulesToAbi(modules: any): Array<{ address: string; m
   return entries.map(([n, m]) => ({ address: m.address, module: normalizedModule(n, m) }))
 }
 
+// A Sui ABI downloaded by an older CLI is the raw JSON-RPC
+// `getNormalizedMoveModulesByPackage` result: a `{ moduleName: { structs,
+// exposedFunctions, ... } }` map. The v2 codegen (see comment at top of file)
+// instead consumes the gRPC array shape produced by `normalizedModulesToAbi`.
+// Feeding a legacy-shaped file straight to codegen throws
+// (`modules.map is not a function`), so `sentio add`/`build`/`gen` fail whenever
+// a stale Sui ABI is already sitting in `abis/sui`. Detect that legacy shape.
+function isLegacyNormalizedModules(parsed: any): boolean {
+  // The gRPC shape is an array; the legacy JSON-RPC shape is a plain object map.
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return false
+  }
+  const map = parsed.result ?? parsed
+  if (!map || typeof map !== 'object' || Array.isArray(map)) {
+    return false
+  }
+  return Object.values(map).some((m: any) => m && typeof m === 'object' && ('exposedFunctions' in m || 'structs' in m))
+}
+
+// A legacy-shaped Sui ABI file on disk, together with the package address and
+// network recovered from its name/content so it can be re-downloaded.
+export interface LegacySuiAbi {
+  file: string
+  address: string
+  chain: SuiChainId.SUI_MAINNET | SuiChainId.SUI_TESTNET
+}
+
+// Recover the package address of a legacy Sui ABI: prefer the 0x-prefixed file
+// name (what `sentio add` uses by default), otherwise fall back to the `address`
+// carried by the normalized modules (covers files saved under a custom --name).
+function legacySuiPackageAddress(file: string, parsed: any): string | undefined {
+  const base = path.basename(file, '.json')
+  if (base.startsWith('0x')) {
+    return base
+  }
+  const map = parsed?.result ?? parsed
+  for (const module of Object.values(map ?? {})) {
+    const address = (module as any)?.address
+    if (typeof address === 'string' && address.startsWith('0x')) {
+      return address
+    }
+  }
+  return undefined
+}
+
+// Recursively collect every legacy-shaped Sui ABI under `baseDir`, resolving the
+// package address and network (testnet ABIs live under `<baseDir>/testnet`, see
+// getABIFilePath) for each. Pure/offline — the download happens in
+// `redownloadLegacySuiAbis`. Iota still consumes the legacy shape, so this must
+// only ever be pointed at the Sui directory.
+export function collectLegacySuiAbis(baseDir: string): LegacySuiAbi[] {
+  const result: LegacySuiAbi[] = []
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) {
+      return
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(fullPath)
+        continue
+      }
+      if (!entry.name.endsWith('.json')) {
+        continue
+      }
+      let parsed: any
+      try {
+        parsed = JSON.parse(fs.readFileSync(fullPath, 'utf8'))
+      } catch {
+        continue
+      }
+      if (!isLegacyNormalizedModules(parsed)) {
+        continue
+      }
+      const address = legacySuiPackageAddress(fullPath, parsed)
+      if (!address) {
+        console.log(
+          chalk.yellow(`Skipping legacy Sui ABI ${fullPath}: cannot resolve package address, re-download it manually`)
+        )
+        continue
+      }
+      const isTestnet = path.relative(baseDir, fullPath).split(path.sep).includes('testnet')
+      result.push({ file: fullPath, address, chain: isTestnet ? SuiChainId.SUI_TESTNET : SuiChainId.SUI_MAINNET })
+    }
+  }
+  walk(baseDir)
+  return result
+}
+
+// Sui ABIs downloaded by an older CLI are stored in the legacy JSON-RPC map
+// shape, which the current gRPC codegen can't read (`modules.map is not a
+// function`), so a stale Sui ABI left in `abis/sui` makes `sentio add`/`build`/
+// `gen` fail for the whole project. Collect every such file, then re-download it
+// through getABI so it lands in the current shape with fresh on-chain data.
+// Fetched sequentially with a delay between same-network requests to stay under
+// Sui public-RPC rate limits, matching the "download missing ABI" loop.
+export async function redownloadLegacySuiAbis(baseDir = path.resolve('abis', 'sui')): Promise<void> {
+  const legacy = collectLegacySuiAbis(baseDir)
+  if (legacy.length === 0) {
+    return
+  }
+  console.log(chalk.yellow(`Found ${legacy.length} legacy Sui ABI file(s), re-downloading in the current format`))
+  let previousChain = ''
+  for (const { file, chain, address } of legacy) {
+    if (chain === previousChain) {
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+    } else {
+      previousChain = chain
+    }
+    const res = await getABI(chain, address, path.basename(file, '.json'))
+    writeABIFile(res.abi, file)
+  }
+}
+
 export async function getABI(
   chain: ChainId,
   address: string,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra'
 import { checkSdkCompatibility, getPackageRoot } from '../utils.js'
 import { Command } from '@commander-js/extra-typings'
 import { CHAIN_TYPES, loadProcessorConfig } from '../config.js'
-import { getABIFilePath, getABI, writeABIFile } from '../abi.js'
+import { getABIFilePath, getABI, writeABIFile, redownloadLegacySuiAbis } from '../abi.js'
 import { execStep, execPackageManager } from '../execution.js'
 import { CommandOptionsType } from './types.js'
 
@@ -111,6 +111,12 @@ export async function codegen(genExample: boolean) {
   }
 
   const outputBase = path.resolve('src', 'types')
+
+  // Re-download any Sui ABIs saved by an older CLI in the legacy JSON-RPC map
+  // shape; the current codegen only reads the gRPC array shape, so a stale file
+  // left in abis/sui would otherwise make the Sui codegen throw for the whole
+  // project.
+  await redownloadLegacySuiAbis(path.resolve('abis', 'sui'))
 
   for (const gen of CHAIN_TYPES) {
     try {


### PR DESCRIPTION
## Problem

If `abis/sui` already contains a Sui ABI downloaded by an **older CLI**, `sentio add` (and `sentio build` / `sentio gen`) fails.

Older CLIs stored Sui ABIs as the raw JSON-RPC `getNormalizedMoveModulesByPackage` result — a `{ moduleName: { structs, exposedFunctions, ... } }` map. Since the Sui → `@typemove` 2.0 gRPC migration (#40), codegen only consumes the gRPC array shape `[{ address, module: { datatypes, functions } }]`. Feeding a legacy-shaped file to `SuiChainAdapter.toInternalModules` throws `modules.map is not a function`, which aborts the whole Sui codegen — regardless of which chain's contract you were adding.

(Iota still consumes the legacy shape, so its ABIs are intentionally left untouched.)

## Fix

Before running codegen, `redownloadLegacySuiAbis` scans `abis/sui` for legacy-shaped files, resolves each package address (from the `0x…` file name, or the `address` in the module content for files saved under a custom `--name`) and network (`testnet/` sub-path), and **re-downloads** them through `getABI` so they land in the current gRPC array shape with fresh on-chain data. Downloads run sequentially with the same rate-limit delay as the existing "download missing ABI" loop.

## Tradeoff

Re-download (vs. in-place conversion) fetches fresh data through the canonical path, but needs network access and can hard-fail if a stale **testnet** package was wiped by a testnet reset (404 → `getABI` exits) — consistent with how the existing missing-ABI download already behaves.

## Testing

- Reproduced the original `modules.map is not a function` failure.
- New offline unit tests for `collectLegacySuiAbis` (file-name address, testnet sub-path, custom-name content fallback, ignores already-migrated files).
- Verified end-to-end against a real mainnet package (`0xdee9`): stale legacy file → re-downloaded → correct `[{ address, module: { name, datatypes, functions } }]` shape.
- `tsc --noEmit`, prettier, and eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)