### PR TITLE
fix(runtime): stop dropping exports from process result when WRITE_V2_EVENT_LOGS=false

### DIFF
--- a/packages/runtime/src/service-v3.test.ts
+++ b/packages/runtime/src/service-v3.test.ts
@@ -105,5 +105,7 @@ describe('Test Service V3 with worker without partition', () => {
 
     assert.ok(result, 'Result should be present in the response')
     assert.ok(result?.states, 'States should be present in the result')
+    assert.strictEqual(result?.exports?.length, 1, 'Exports should be forwarded in the result')
+    assert.strictEqual(result?.exports?.[0]?.payload, '{"test":1}', 'Export payload should be preserved')
   })
 })

--- a/packages/runtime/src/service-v3.ts
+++ b/packages/runtime/src/service-v3.ts
@@ -28,7 +28,6 @@ type ProcessStreamResponseV3Init = MessageInitShape<typeof ProcessStreamResponse
 
 const { process_binding_count, process_binding_time, process_binding_error } = processMetrics
 
-const WRITE_V2_EVENT_LOGS = process.env.WRITE_V2_EVENT_LOGS !== 'false'
 const TIME_SERIES_RESULT_BATCH_SIZE = 1000
 
 export class ProcessorServiceImplV3 implements ServiceImpl<typeof ProcessorV3> {
@@ -186,7 +185,7 @@ export class ProcessorServiceImplV3 implements ServiceImpl<typeof ProcessorV3> {
           processId,
           value: {
             case: 'result',
-            value: WRITE_V2_EVENT_LOGS ? otherResults : create(ProcessResultSchema, { states: result.states })
+            value: otherResults
           }
         })
       })

--- a/packages/runtime/src/test-processor.test.ts
+++ b/packages/runtime/src/test-processor.test.ts
@@ -26,7 +26,8 @@ export class TestPlugin extends Plugin {
     }
 
     return create(ProcessResultSchema, {
-      states: {}
+      states: {},
+      exports: [{ payload: '{"test":1}' }]
     })
   }
   supportedHandlers = [HandlerType.UNKNOWN, HandlerType.ETH_LOG]


### PR DESCRIPTION
## Problem

`WRITE_V2_EVENT_LOGS` was a dev-phase toggle introduced during the v3 event/metric rollout to make it easy to compare v2 and v3 data side by side. When set to `false`, the v3 service replaced the final `result` message with a bare `{ states }`:

```ts
value: WRITE_V2_EVENT_LOGS ? otherResults : create(ProcessResultSchema, { states: result.states })
```

The v2 result fields this flag originally guarded (gauges/counters/logs/events) have since been removed from `ProcessResult`, which now only contains `exports`, `states`, and `timeseriesResult`. Timeseries data is already sent separately via batched `tsRequest` messages, so the only remaining effect of `WRITE_V2_EVENT_LOGS=false` was **silently discarding `exports`** — every `Exporter.emit()` payload was dropped before reaching the host, breaking webhook/export delivery entirely for SDK 4.x processors running with that setting.

## Fix

- Remove the obsolete `WRITE_V2_EVENT_LOGS` flag and always send the full remaining result (`exports` + `states`) back.
- Regression coverage: `TestPlugin` now returns an export payload, and the service-v3 stream test asserts the export is forwarded intact in the final `result` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)