### PR TITLE
fix(runtime): flush buffered upserts before reads and process result

### DIFF
--- a/packages/runtime/src/db-context.test.ts
+++ b/packages/runtime/src/db-context.test.ts
@@ -1,0 +1,64 @@
+import { describe, test } from 'node:test'
+import assert from 'assert'
+import { Subject } from 'rxjs'
+import { create } from '@bufbuild/protobuf'
+import { RichStructSchema } from '@sentio/protos'
+import { DataBindingContext } from './db-context.js'
+
+// These tests pin the ordering guarantees the driver relies on: with the
+// default batching on (STORE_BATCH_MAX_IDLE=1, STORE_BATCH_SIZE=10), a buffered
+// upsert must be flushed to the stream before any later read on the same
+// context, and must never be emitted once the context is closed.
+
+function upsertReq(id: string) {
+  return {
+    case: 'upsert' as const,
+    value: { entity: ['E'], id: [id], entityData: [create(RichStructSchema, {})] }
+  }
+}
+
+function collect(subject: Subject<any>) {
+  const ops: string[] = []
+  subject.subscribe((msg: any) => {
+    if (msg?.value?.case === 'dbRequest') {
+      ops.push(msg.value.value.op?.case ?? 'unknown')
+    } else if (msg?.value?.case) {
+      ops.push(msg.value.case)
+    }
+  })
+  return ops
+}
+
+describe('DataBindingContext write/read ordering', () => {
+  test('a read flushes the pending upsert batch before it (read-your-writes)', () => {
+    const subject = new Subject<any>()
+    const ops = collect(subject)
+    const ctx = new DataBindingContext(1, subject)
+
+    // Fire-and-forget upsert: with batching on this only schedules the batch,
+    // nothing is sent yet.
+    void ctx.sendRequest(upsertReq('1'))
+    assert.deepEqual(ops, [], 'batched upsert must not be sent synchronously')
+
+    // A get on the same context must flush the buffered upsert first, so the
+    // upsert dbRequest is on the wire ahead of the get.
+    void ctx.sendRequest({ case: 'get', value: { entity: 'E', id: '1' } })
+    assert.deepEqual(ops, ['upsert', 'get'], 'read must observe the prior write')
+  })
+
+  test('a pending batch is never emitted after close()', async () => {
+    const subject = new Subject<any>()
+    const ops = collect(subject)
+    const ctx = new DataBindingContext(2, subject)
+
+    // close() rejects any still-pending write promise; swallow it here since
+    // this test only asserts nothing is *emitted* after close.
+    ctx.sendRequest(upsertReq('1')).catch(() => {}) // schedules the batch timer
+    ctx.close()
+
+    // Wait well past STORE_BATCH_MAX_IDLE (1ms): the timer must have been
+    // cancelled and the closed guard must suppress any emission.
+    await new Promise((r) => setTimeout(r, 20))
+    assert.deepEqual(ops, [], 'no emission may happen after the context is closed')
+  })
+})

--- a/packages/runtime/src/db-context.ts
+++ b/packages/runtime/src/db-context.ts
@@ -61,6 +61,10 @@ export abstract class AbstractStoreContext implements IStoreContext {
   >()
   private statsInterval: NodeJS.Timeout | undefined
   private pendings: Promise<unknown>[] = []
+  // Set once the process has finished and the context was closed. Guards
+  // against a lingering batch timer emitting after the final result (which
+  // would both lose the write and desync the reused processor stream).
+  private closed = false
 
   constructor(readonly processId: number) {}
 
@@ -78,6 +82,12 @@ export abstract class AbstractStoreContext implements IStoreContext {
       // batch upsert if possible
       return this.sendUpsertInBatch(request.value as DBRequest_DBUpsert)
     }
+
+    // Read-your-writes: any non-upsert op (get/list/delete) must observe the
+    // upserts issued before it. Flush the pending batch first so its dbRequest
+    // is sent ahead of this op on the same stream; the driver applies stream
+    // ops in arrival order, so the read/delete sees the buffered writes.
+    this.sendBatch()
 
     const requestType = request.case as RequestType
     const opId = StoreContext.opCounter++
@@ -160,6 +170,16 @@ export abstract class AbstractStoreContext implements IStoreContext {
   }
 
   close() {
+    this.closed = true
+    // Drop any un-flushed batch and cancel its timer so it can never emit
+    // after close. In the normal path awaitPendings() has already flushed it;
+    // reaching here with a pending batch means the process ended without
+    // awaiting the write (e.g. a handler error), so emitting it now would be
+    // both too late (lost from this checkpoint) and stream-corrupting.
+    if (this.upsertBatch) {
+      clearTimeout(this.upsertBatch.timer)
+      this.upsertBatch = undefined
+    }
     for (const [opId, defer] of this.defers) {
       // console.warn('context closed before db response', opId)
       defer.reject(new Error('context closed before db response, processId: ' + this.processId + ' opId: ' + opId))
@@ -221,6 +241,11 @@ export abstract class AbstractStoreContext implements IStoreContext {
   }
 
   private sendBatch() {
+    // Never emit once the context is closed: the process already sent its
+    // final result and the stream may have been handed to another process.
+    if (this.closed) {
+      return
+    }
     if (this.upsertBatch) {
       const { request, opId, timer } = this.upsertBatch
       // console.debug('sending batch upsert', opId, 'batch size', request?.entity.length)
@@ -242,6 +267,17 @@ export abstract class AbstractStoreContext implements IStoreContext {
   }
 
   async awaitPendings() {
+    // Flush any buffered upsert batch and wait for its ack before returning.
+    // Callers use this to guarantee every write has been sent AND applied by
+    // the driver before the process emits its final result. Without it the
+    // batch's setTimeout could fire after the result — losing the write and
+    // leaving a stray message on the pooled processor stream (surfacing to the
+    // driver as ERR200 "unexpected ProcessID").
+    if (this.upsertBatch) {
+      const { promise } = this.upsertBatch
+      this.sendBatch()
+      this.pendings.push(promise)
+    }
     await Promise.all(this.pendings)
   }
 }


### PR DESCRIPTION
## Problem

`ctx.store` upserts are buffered and flushed by a short `setTimeout` batch
(`STORE_BATCH_MAX_IDLE`, `STORE_BATCH_SIZE`). The batch's send (`doSend`) is
therefore decoupled from the logical order of operations, which opens three
ordering gaps that let a buffered write escape its process:

1. **Write flushed after the process result.** `awaitPendings()` awaited only
   `this.pendings`; a still-pending (non-`NO_WAIT`) batch was neither flushed
   nor awaited. So the 1ms batch timer could fire *after* the process emitted
   its final result — the upsert was lost from that process's checkpoint, and
   the late `dbRequest` landed on the shared stream out of band. Because the
   host reuses process streams, the next process reads the stray message and
   fails with an unexpected-process-id error (and crash-loops). This is
   independent of process-id uniqueness.

2. **Reads don't observe prior buffered writes.** A `get`/`list`/`delete` was
   sent immediately without flushing a pending upsert batch, so a read issued
   after an upsert could be sent ahead of it on the wire and miss it —
   read-your-writes broken when the upsert wasn't awaited, or when
   `STORE_UPSERT_NO_WAIT` is set (in which case `await upsert` returns before
   the write is applied).

3. **Lingering timer after close.** `close()` left the batch `setTimeout`
   armed, so a stray flush could still fire after the context was gone.

## Fix (`db-context.ts`)

- `awaitPendings()` flushes any pending batch and awaits its ack before
  returning, so every write is sent+applied before the caller emits the
  process result. The result is now guaranteed to be the process's last
  message.
- Every non-upsert op (`get`/`list`/`delete`) flushes the pending batch first,
  so it is ordered behind prior writes on the same stream (the host applies
  stream ops in arrival order) — read-your-writes regardless of await style or
  `STORE_UPSERT_NO_WAIT`.
- `close()` cancels the batch timer and drops the batch; a `closed` guard makes
  `sendBatch()` a no-op after close, so nothing can be emitted post-close.

## Tests

Adds `db-context.test.ts`: a read flushes the pending upsert batch before it
(read-your-writes), and no emission happens after `close()`. Full runtime suite
passes (16/16), `tsc --noEmit` clean.

## Rollout note

The runtime ships inside the uploaded processor bundle, so this takes effect
after a processor is rebuilt against the new SDK and re-uploaded.