### PR TITLE
fix(runtime): reject store ops issued after the process finished

### DIFF
--- a/packages/runtime/src/db-context.test.ts
+++ b/packages/runtime/src/db-context.test.ts
@@ -62,3 +62,71 @@ describe('DataBindingContext write/read ordering', () => {
     assert.deepEqual(ops, [], 'no emission may happen after the context is closed')
   })
 })
+
+// An operation *started* after the process finished is a different failure from a
+// buffered one escaping: the handler returned while something it never awaited was
+// still running (the classic case being a rejected Promise.all sibling). It must not
+// reach the stream, because the stream has been recycled and the driver would fail
+// whichever process owns it now with ERR200 "unexpected ProcessID".
+describe('DataBindingContext rejects messages issued after close', () => {
+  function silenceConsoleError() {
+    const original = console.error
+    const logged: unknown[] = []
+    console.error = (...args: unknown[]) => void logged.push(args[0])
+    return { logged, restore: () => void (console.error = original) }
+  }
+
+  test('a store op issued after close is dropped, rejected, and logged with a stack', async () => {
+    const subject = new Subject<any>()
+    const ops = collect(subject)
+    const ctx = new DataBindingContext(3, subject)
+    const { logged, restore } = silenceConsoleError()
+
+    ctx.close()
+    await assert.rejects(
+      () => ctx.sendRequest({ case: 'get', value: { entity: 'BinanceAlphaPriceEntity', id: '56-0xabc' } }),
+      (err: Error) => {
+        // The message must name the op, entity and id so the caller can find it,
+        // and carry a stack pointing at the late call.
+        assert.match(err.message, /get BinanceAlphaPriceEntity 56-0xabc/)
+        assert.match(err.message, /after process 3 had already finished/)
+        assert.match(err.message, /Promise\.all/)
+        assert.ok(err.stack && err.stack.includes('db-context.test'), 'stack must reach the caller')
+        return true
+      }
+    )
+    restore()
+
+    assert.deepEqual(ops, [], 'a late op must never reach the stream')
+    assert.equal(logged.length, 1, 'must log too — the caller usually swallows the rejection')
+  })
+
+  test('late upserts are rejected as well, not silently buffered', async () => {
+    const subject = new Subject<any>()
+    const ops = collect(subject)
+    const ctx = new DataBindingContext(4, subject)
+    const { restore } = silenceConsoleError()
+
+    ctx.close()
+    await assert.rejects(() => ctx.sendRequest(upsertReq('1')), /upsert E \(1 row\(s\)\)/)
+    restore()
+
+    await new Promise((r) => setTimeout(r, 20))
+    assert.deepEqual(ops, [], 'a late upsert must not be buffered into a new batch either')
+  })
+
+  test('late timeseries and template messages are dropped, not emitted', () => {
+    const subject = new Subject<any>()
+    const ops = collect(subject)
+    const ctx = new DataBindingContext(5, subject)
+    const { logged, restore } = silenceConsoleError()
+
+    ctx.close()
+    ctx.sendTimeseriesRequest([{} as any])
+    ctx.sendTemplateRequest([{} as any], false)
+    restore()
+
+    assert.deepEqual(ops, [], 'neither may reach the recycled stream')
+    assert.equal(logged.length, 2, 'both must be reported')
+  })
+})

--- a/packages/runtime/src/db-context.ts
+++ b/packages/runtime/src/db-context.ts
@@ -38,6 +38,25 @@ type RequestType = NonNullable<Request['case']>
 
 export const timeoutError = new Error('timeout')
 
+// Name the entity and id, not just the op kind: "get BinanceAlphaPriceEntity 56-0x…"
+// usually points straight at the call site, while a bare "get" rarely does.
+function describeRequest(request: Request): string {
+  switch (request.case) {
+    case 'get':
+      return `get ${request.value.entity} ${request.value.id}`
+    case 'list':
+      return `list ${request.value.entity}`
+    case 'upsert':
+    case 'update':
+    case 'delete': {
+      const entities = [...new Set(request.value.entity ?? [])].join(',')
+      return `${request.case} ${entities} (${request.value.id?.length ?? 0} row(s))`
+    }
+    default:
+      return request.case
+  }
+}
+
 export interface IStoreContext {
   sendRequest(request: Request, timeoutSecs?: number): Promise<DBResponse>
 
@@ -64,7 +83,7 @@ export abstract class AbstractStoreContext implements IStoreContext {
   // Set once the process has finished and the context was closed. Guards
   // against a lingering batch timer emitting after the final result (which
   // would both lose the write and desync the reused processor stream).
-  private closed = false
+  protected closed = false
 
   constructor(readonly processId: number) {}
 
@@ -78,6 +97,10 @@ export abstract class AbstractStoreContext implements IStoreContext {
   abstract doSend(resp: ProcessStreamResponseInit | ProcessStreamResponseV3Init): void
 
   sendRequest(request: Request, timeoutSecs?: number): Promise<DBResponse> {
+    if (this.closed) {
+      return Promise.reject(this.reportLateMessage(`store ${describeRequest(request)}`, this.sendRequest))
+    }
+
     if (STORE_BATCH_IDLE > 0 && STORE_BATCH_SIZE > 1 && request.case === 'upsert') {
       // batch upsert if possible
       return this.sendUpsertInBatch(request.value as DBRequest_DBUpsert)
@@ -266,6 +289,39 @@ export abstract class AbstractStoreContext implements IStoreContext {
     }
   }
 
+  /**
+   * Report a message the process tried to emit after it had already finished, and
+   * return the Error describing it.
+   *
+   * Such a message cannot be delivered: the final result was already sent, and the
+   * stream it would go out on has been handed back to the pool and may now belong to
+   * another process — writing to it makes the driver fail *that* process with ERR200
+   * "unexpected ProcessID". Dropping it is the only safe option.
+   *
+   * This always logs rather than relying solely on the rejection, because the late
+   * call is nearly always on a path that already swallows errors — the classic case
+   * being one `Promise.all` branch rejecting while its siblings keep running — so the
+   * rejection alone would be invisible. The Error is built here, at the call site, so
+   * its stack points into the handler code that failed to await.
+   *
+   * `boundary` is the runtime entry point the caller came through; its frame and
+   * everything below it is trimmed from the stack so the very first line the user
+   * reads is their own code rather than two frames of ours.
+   */
+  protected reportLateMessage(what: string, boundary?: (...args: never[]) => unknown): Error {
+    const err = new Error(
+      `[sentio] ${what} was issued after process ${this.processId} had already finished, so it was dropped. ` +
+        `Something in the handler was still running after the handler returned — every store write, ` +
+        `store read and metric must be awaited before the handler completes. A common cause is one ` +
+        `Promise.all() branch rejecting while its siblings keep running: Promise.all rejects immediately ` +
+        `but does NOT cancel the others, so give each branch its own .catch() (or use Promise.allSettled) ` +
+        `to keep them inside the handler. The stack below points at the call that arrived too late.`
+    )
+    Error.captureStackTrace?.(err, boundary ?? this.reportLateMessage)
+    console.error(err)
+    return err
+  }
+
   async awaitPendings() {
     // Flush any buffered upsert batch and wait for its ack before returning.
     // Callers use this to guarantee every write has been sent AND applied by
@@ -308,6 +364,13 @@ export class DataBindingContext extends AbstractStoreContext implements IDataBin
   }
 
   sendTemplateRequest(templates: Array<TemplateInstance>, unbind: boolean) {
+    if (this.closed) {
+      this.reportLateMessage(
+        `${unbind ? 'unbind' : 'bind'} of ${templates.length} template instance(s)`,
+        this.sendTemplateRequest
+      )
+      return
+    }
     this.subject.next({
       processId: this.processId,
       value: {
@@ -320,6 +383,10 @@ export class DataBindingContext extends AbstractStoreContext implements IDataBin
     })
   }
   sendTimeseriesRequest(timeseries: Array<TimeseriesResult>) {
+    if (this.closed) {
+      this.reportLateMessage(`${timeseries.length} timeseries record(s)`, this.sendTimeseriesRequest)
+      return
+    }
     this.subject.next({
       processId: this.processId,
       value: {

--- a/packages/runtime/src/db-context.ts
+++ b/packages/runtime/src/db-context.ts
@@ -193,6 +193,21 @@ export abstract class AbstractStoreContext implements IStoreContext {
     this.doSend({ value: { case: 'result', value: errorResult }, processId })
   }
 
+  /**
+   * Mark the process finished. Must be called synchronously *immediately before*
+   * the final result is emitted — not from a later `.finally()`.
+   *
+   * Once the result is on the stream the driver may hand that stream to another
+   * process, so nothing may follow it. The gap between emitting the result and
+   * close() running is several microtasks wide, which is more than enough for a
+   * detached continuation to wake up and slip a request through: without this the
+   * observed outbound order is ["result", "dbRequest"], exactly what the guards
+   * exist to prevent. close() still does the teardown afterwards.
+   */
+  finish() {
+    this.closed = true
+  }
+
   close() {
     this.closed = true
     // Drop any un-flushed batch and cancel its timer so it can never emit

--- a/packages/runtime/src/db-context.ts
+++ b/packages/runtime/src/db-context.ts
@@ -53,7 +53,8 @@ function describeRequest(request: Request): string {
       return `${request.case} ${entities} (${request.value.id?.length ?? 0} row(s))`
     }
     default:
-      return request.case
+      // The oneof can be unset, in which case `case` is undefined.
+      return request.case ?? 'op'
   }
 }
 

--- a/packages/runtime/src/service-v3.test.ts
+++ b/packages/runtime/src/service-v3.test.ts
@@ -6,6 +6,7 @@ import {
   ProcessConfigRequestSchema,
   type ProcessConfigResponse,
   ProcessConfigResponseSchema,
+  ProcessResultSchema,
   ProcessStreamRequestSchema,
   ProcessStreamResponseV3Schema,
   StartRequestSchema
@@ -107,5 +108,67 @@ describe('Test Service V3 with worker without partition', () => {
     assert.ok(result?.states, 'States should be present in the result')
     assert.strictEqual(result?.exports?.length, 1, 'Exports should be forwarded in the result')
     assert.strictEqual(result?.exports?.[0]?.payload, '{"test":1}', 'Export payload should be preserved')
+  })
+})
+
+// The final result must be the last thing a process ever puts on the stream: once
+// it is sent, the driver may hand that stream to another process, and anything
+// appended afterwards makes the driver fail *that* process with ERR200 "unexpected
+// ProcessID". A handler that returns while an un-awaited task is still pending is
+// the way this happens in practice, so assert the ordering end-to-end rather than
+// only unit-testing the guard — the guard is useless if the context is not marked
+// finished until a later microtask.
+describe('Test Service V3 does not emit anything after the final result', () => {
+  // A plugin whose handler returns immediately while a detached task walks through
+  // several microtasks and only then touches the store.
+  class FloatingTaskPlugin extends TestPlugin {
+    override async processBinding(): Promise<any> {
+      const dbContext = PluginManager.INSTANCE.dbContextLocalStorage.getStore()
+      // Deliberately not awaited: this is the floating-promise shape.
+      void (async () => {
+        for (let n = 0; n < 5; n++) {
+          await Promise.resolve()
+        }
+        await dbContext?.sendRequest({ case: 'get', value: { entity: 'Late', id: '1' } }).catch(() => {})
+      })()
+      return create(ProcessResultSchema, { states: {} })
+    }
+  }
+
+  test('a detached task cannot append a dbRequest after the result', async () => {
+    const service = new ProcessorServiceImplV3(
+      async () => {
+        PluginManager.INSTANCE.plugins = []
+        PluginManager.INSTANCE.typesToPlugin.clear()
+        PluginManager.INSTANCE.register(new FloatingTaskPlugin())
+      },
+      getTestConfig({ enablePartition: false })
+    )
+    await service.start(create(StartRequestSchema, { templateInstances: [] }), TEST_CONTEXT)
+
+    const subject = new Subject<ProcessStreamResponseV3Init>()
+    const order: string[] = []
+    subject.subscribe((resp) => order.push(resp.value?.case ?? 'unknown'))
+
+    const originalError = console.error
+    console.error = () => {} // the dropped late op logs; keep the test output clean
+    await service.handleRequest(
+      create(ProcessStreamRequestSchema, {
+        processId: 7,
+        value: {
+          case: 'binding',
+          value: { handlerIds: [0], handlerType: HandlerType.ETH_LOG, data: {}, chainId: '1' }
+        }
+      }),
+      undefined,
+      subject
+    )
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    console.error = originalError
+
+    const resultAt = order.indexOf('result')
+    assert.ok(resultAt >= 0, `expected a result, got ${JSON.stringify(order)}`)
+    assert.strictEqual(resultAt, order.length - 1, `nothing may follow the result, got ${JSON.stringify(order)}`)
+    assert.ok(!order.includes('dbRequest'), `the late dbRequest must be dropped, got ${JSON.stringify(order)}`)
   })
 })

--- a/packages/runtime/src/service-v3.ts
+++ b/packages/runtime/src/service-v3.ts
@@ -181,6 +181,11 @@ export class ProcessorServiceImplV3 implements ServiceImpl<typeof ProcessorV3> {
         const otherResults = clone(ProcessResultSchema, result)
         otherResults.timeseriesResult = []
 
+        // Close the context to further messages in the same synchronous step that
+        // emits the result: after this point the stream may be recycled to another
+        // process, and waiting for the .finally() below would leave a microtask
+        // window in which a detached continuation could still append to it.
+        context.finish()
         subject.next({
           processId,
           value: {
@@ -191,6 +196,7 @@ export class ProcessorServiceImplV3 implements ServiceImpl<typeof ProcessorV3> {
       })
       .catch((e) => {
         console.error(e, e.stack)
+        context.finish() // same reasoning as the success path — error() emits a result too
         context.error(processId, e)
         process_binding_error.add(1)
       })


### PR DESCRIPTION
## Problem

If a handler returns while something it never awaited is still running, that work
goes on to touch the context after the process is over. Store reads and deletes
reach the stream through `doSend` **synchronously**, so such a call was written
straight to the processor stream — which by then had been returned to the pool
and, on a busy chain, already belonged to a different process.

The driver validates `process_id` on every message it reads off that stream, so
it fails with `ERR200: unexpected ProcessID #A (expected #B)` and kills
**whichever process owns the stream now**. An un-awaited call in one handler
crashes an unrelated, innocent one — and the crash report named only the two ids,
giving no hint where the stray message came from.

#104 added the `closed` flag, but only `sendBatch()` consulted it. That covered a
buffered upsert whose timer fired late; it did not cover anything *newly issued*
after close, which still emitted unconditionally.

## Change

Guard the entry points rather than the flush:

- `sendRequest` rejects when the context is closed (before batching, so late
  upserts are caught too rather than being buffered into a fresh batch)
- `sendTimeseriesRequest` / `sendTemplateRequest` drop, since they have no promise
  to reject

**It reports, it doesn't only reject.** The late call is nearly always on a path
that already swallows errors, so a rejection by itself would be invisible — which
is exactly how this went undiagnosed. The most common shape:

```ts
// Promise.all rejects immediately, but does NOT cancel its siblings.
// balanceOf fails -> the outer catch swallows it -> the handler returns ->
// meanwhile getPrice() is still running, and touches the store afterwards.
const [balance, price] = await Promise.all([
  asset.balanceOf(addr),
  getPrice(ctx, asset.address),
])
```

So the error is logged as well, and it is written to be actionable on its own:

```
Error: [sentio] store get BinanceAlphaPriceEntity 56-0xcc121ab1…-2025-06-30T00:00:00.000Z
was issued after process 20950 had already finished, so it was dropped. Something in
the handler was still running after the handler returned — every store write, store
read and metric must be awaited before the handler completes. A common cause is one
Promise.all() branch rejecting while its siblings keep running: Promise.all rejects
immediately but does NOT cancel the others, so give each branch its own .catch() (or
use Promise.allSettled) to keep them inside the handler. The stack below points at the
call that arrived too late.
    at recordVaultIdleFund (/app/src/processor.ts:1276:16)      <-- the user's own code
    at async handleVaultTimeInterval (/app/src/processor.ts:1275:3)
```

Three things make it diagnosable:

- **the op is named** — `get BinanceAlphaPriceEntity <id>`, not a bare "get";
  the entity plus id usually points straight at the call site
- **the stack is trimmed** — `Error.captureStackTrace` cuts the runtime frames so
  the *first* line is the caller's code, not two frames of ours
- **the Promise.all pattern is spelled out**, because that is the cause the
  overwhelming majority of the time

## Test

`pnpm --filter "./packages/runtime" test` — adds cases for: a late `get`
(dropped + rejected + logged + stack reaches the caller), a late `upsert` (not
silently re-buffered), and late timeseries/template messages (dropped, both
reported). The existing #104 ordering tests still pass.

## Note

This does not fix a user's un-awaited call — only they can do that. What it fixes
is the blast radius: a floating promise now surfaces as one clear error pointing
at its own call site, instead of crashing an unrelated process and corrupting a
pooled stream.