### PR TITLE
feat(cli): add devnet as a Sentio Network target

### DIFF
--- a/packages/cli/src/commands/stop-processor.ts
+++ b/packages/cli/src/commands/stop-processor.ts
@@ -16,7 +16,7 @@ export function createStopProcessorCommand() {
   return new Command('stop')
     .description('Stop a processor. Uses Sentio Network contract when --sentio-network is specified.')
     .argument('<processorId>', 'ID of the processor to stop')
-    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet)')
+    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet or devnet2)')
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')

--- a/packages/cli/src/commands/stop-processor.ts
+++ b/packages/cli/src/commands/stop-processor.ts
@@ -16,7 +16,7 @@ export function createStopProcessorCommand() {
   return new Command('stop')
     .description('Stop a processor. Uses Sentio Network contract when --sentio-network is specified.')
     .argument('<processorId>', 'ID of the processor to stop')
-    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet or devnet2)')
+    .option('--sentio-network <network>', 'Stop via Sentio Network contract (testnet or devnet)')
     .option('--host <host>', 'Override Sentio host')
     .option('--api-key <key>', 'Use an explicit API key instead of saved credentials')
     .option('--token <token>', 'Use an explicit bearer token instead of saved credentials')

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -85,17 +85,14 @@ export function createUploadCommand() {
     .option('--token <token>', '(Optional) Manually provide token rather than use saved credential')
     .option('--host <host>', '(Optional) Override Sentio Host name')
     .option('--num-workers <count>', '(Optional) Number of processor workers to start', myParseInt)
-    .option(
-      '--sentio-network <network>',
-      '(Optional) Sentio network to connect to, can be testnet or mainnet'
-    )
+    .option('--sentio-network <network>', '(Optional) Sentio network to connect to, can be testnet, devnet2 or mainnet')
     .option(
       '--required-chain-id <chain_id...>',
       '(Optional) Specify chain IDs required for the Sentio network. This option is only available when --sentio-network is used. If omitted, all chain IDs from the project configuration (contracts or network overrides) will be used.'
     )
     .option(
       '--no-platform',
-      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Only testnet is supported.'
+      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Supported networks: testnet, devnet2.'
     )
     .option(
       '--ipfs-put-url <url>',

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -85,14 +85,14 @@ export function createUploadCommand() {
     .option('--token <token>', '(Optional) Manually provide token rather than use saved credential')
     .option('--host <host>', '(Optional) Override Sentio Host name')
     .option('--num-workers <count>', '(Optional) Number of processor workers to start', myParseInt)
-    .option('--sentio-network <network>', '(Optional) Sentio network to connect to, can be testnet, devnet2 or mainnet')
+    .option('--sentio-network <network>', '(Optional) Sentio network to connect to, can be testnet, devnet or mainnet')
     .option(
       '--required-chain-id <chain_id...>',
       '(Optional) Specify chain IDs required for the Sentio network. This option is only available when --sentio-network is used. If omitted, all chain IDs from the project configuration (contracts or network overrides) will be used.'
     )
     .option(
       '--no-platform',
-      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Supported networks: testnet, devnet2.'
+      'Upload processor directly to Sentio Network without platform support. Requires $PRIVATE_KEY env var. Supported networks: testnet, devnet.'
     )
     .option(
       '--ipfs-put-url <url>',

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -116,6 +116,7 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
       case 'testnet-v2':
         config.sentioNetwork = '7892102'
         break
+      case 'devnet':
       case 'devnet2':
       case 'devnet-v2':
         config.sentioNetwork = '7892301'

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,7 +34,7 @@ export interface YamlProjectConfig {
   silentOverwrite?: boolean
   variables?: Variable[]
   numWorkers?: number // Number of processor worker to start, default to 1
-  sentioNetwork?: string // Sentio network to connect to, can be testnet, devnet2 or mainnet
+  sentioNetwork?: string // Sentio network to connect to, can be testnet, devnet or mainnet
   requiredChainIds?: string[]
 }
 
@@ -117,8 +117,6 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
         config.sentioNetwork = '7892102'
         break
       case 'devnet':
-      case 'devnet2':
-      case 'devnet-v2':
         config.sentioNetwork = '7892301'
         break
       case '7892102':
@@ -127,7 +125,7 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
         config.sentioNetwork = options.sentioNetwork
         break
       default:
-        console.error(`Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet or devnet2 is allowed`)
+        console.error(`Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet or devnet is allowed`)
         process.exit(1)
     }
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -34,7 +34,7 @@ export interface YamlProjectConfig {
   silentOverwrite?: boolean
   variables?: Variable[]
   numWorkers?: number // Number of processor worker to start, default to 1
-  sentioNetwork?: string // Sentio network to connect to, can be testnet or mainnet
+  sentioNetwork?: string // Sentio network to connect to, can be testnet, devnet2 or mainnet
   requiredChainIds?: string[]
 }
 
@@ -116,14 +116,17 @@ export function overrideConfigWithOptions(config: YamlProjectConfig, options: an
       case 'testnet-v2':
         config.sentioNetwork = '7892102'
         break
+      case 'devnet2':
+      case 'devnet-v2':
+        config.sentioNetwork = '7892301'
+        break
       case '7892102':
+      case '7892301':
       case '789210':
         config.sentioNetwork = options.sentioNetwork
         break
       default:
-        console.error(
-          `Invalid sentio network: ${options.sentioNetwork}, only mainnet or testnet is allowed`
-        )
+        console.error(`Invalid sentio network: ${options.sentioNetwork}, only mainnet, testnet or devnet2 is allowed`)
         process.exit(1)
     }
   }

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -26,17 +26,17 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
   addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
 }
 
-// Sentio Network devnet — chain id 7892301, the network also known as devnet2.
-// The original devnet (7892201) has been decommissioned and this chain inherited
-// the canonical `sentio-devnet` slug, so the RPC host is sentio-devnet, NOT
-// sentio-devnet2 (that hostname is not routed and answers "unknown network
-// slug"). Same relationship as testnet-v2 taking over the plain testnet hosts.
+// Sentio Network devnet — chain id 7892301. This replaced the original devnet
+// (7892201), which has been decommissioned, and inherited its hosts: the RPC is
+// sentio-devnet.test-rpc.sentio.xyz and the explorer devnet-explorer.sentio.xyz.
+// `sentio-devnet2` is NOT a thing — that hostname is unrouted and answers
+// "unknown network slug". Same as testnet-v2 taking over the plain testnet hosts.
 //
 // Contracts are deployed deterministically, so every module proxy — and the
 // AddressBook itself — sits at the same address as on testnet. The one exception
 // is `sentio_token`, which here is the WETH9 predeploy; it resolves through the
 // AddressBook like everything else, so nothing in this file needs to know.
-const DEVNET2_CONFIG: SentioNetworkConfig = {
+const DEVNET_CONFIG: SentioNetworkConfig = {
   chainId: 7892301,
   rpcUrl: 'https://sentio-devnet.test-rpc.sentio.xyz',
   explorerUrl: 'https://devnet-explorer.sentio.xyz',
@@ -47,13 +47,13 @@ export function getSentioNetworkConfig(network: string, addressBookOverride?: st
   let config: SentioNetworkConfig
   if (network === 'testnet' || network === 'testnet-v2' || network === '7892102') {
     config = TESTNET_CONFIG
-  } else if (network === 'devnet' || network === 'devnet2' || network === 'devnet-v2' || network === '7892301') {
-    config = DEVNET2_CONFIG
+  } else if (network === 'devnet' || network === '7892301') {
+    config = DEVNET_CONFIG
   } else if (network === 'mainnet' || network === '789210') {
-    console.error(chalk.red('Sentio Network mainnet is not yet supported. Only testnet and devnet2 are available.'))
+    console.error(chalk.red('Sentio Network mainnet is not yet supported. Only testnet and devnet are available.'))
     process.exit(1)
   } else {
-    console.error(chalk.red(`Invalid sentio network: ${network}. Only "testnet" and "devnet2" are supported.`))
+    console.error(chalk.red(`Invalid sentio network: ${network}. Only "testnet" and "devnet" are supported.`))
     process.exit(1)
   }
 

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -26,19 +26,29 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
   addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
 }
 
+// Sentio Network devnet2 — chain id 7892301. Separate chain from testnet, but
+// the contracts are deployed deterministically, so every module proxy (and the
+// AddressBook itself) sits at the same address as on testnet. The one exception
+// is `sentio_token`, which on devnet2 is the WETH9 predeploy — resolved through
+// the AddressBook like everything else, so nothing here needs to know.
+const DEVNET2_CONFIG: SentioNetworkConfig = {
+  chainId: 7892301,
+  rpcUrl: 'https://sentio-devnet2.test-rpc.sentio.xyz',
+  explorerUrl: 'https://devnet2-explorer.sentio.xyz',
+  addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
+}
+
 export function getSentioNetworkConfig(network: string, addressBookOverride?: string): SentioNetworkConfig {
   let config: SentioNetworkConfig
   if (network === 'testnet' || network === 'testnet-v2' || network === '7892102') {
     config = TESTNET_CONFIG
+  } else if (network === 'devnet2' || network === 'devnet-v2' || network === '7892301') {
+    config = DEVNET2_CONFIG
   } else if (network === 'mainnet' || network === '789210') {
-    console.error(
-      chalk.red('Sentio Network mainnet is not yet supported. Only testnet is available.')
-    )
+    console.error(chalk.red('Sentio Network mainnet is not yet supported. Only testnet and devnet2 are available.'))
     process.exit(1)
   } else {
-    console.error(
-      chalk.red(`Invalid sentio network: ${network}. Only "testnet" is supported.`)
-    )
+    console.error(chalk.red(`Invalid sentio network: ${network}. Only "testnet" and "devnet2" are supported.`))
     process.exit(1)
   }
 

--- a/packages/cli/src/network.ts
+++ b/packages/cli/src/network.ts
@@ -26,15 +26,20 @@ const TESTNET_CONFIG: SentioNetworkConfig = {
   addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
 }
 
-// Sentio Network devnet2 — chain id 7892301. Separate chain from testnet, but
-// the contracts are deployed deterministically, so every module proxy (and the
-// AddressBook itself) sits at the same address as on testnet. The one exception
-// is `sentio_token`, which on devnet2 is the WETH9 predeploy — resolved through
-// the AddressBook like everything else, so nothing here needs to know.
+// Sentio Network devnet — chain id 7892301, the network also known as devnet2.
+// The original devnet (7892201) has been decommissioned and this chain inherited
+// the canonical `sentio-devnet` slug, so the RPC host is sentio-devnet, NOT
+// sentio-devnet2 (that hostname is not routed and answers "unknown network
+// slug"). Same relationship as testnet-v2 taking over the plain testnet hosts.
+//
+// Contracts are deployed deterministically, so every module proxy — and the
+// AddressBook itself — sits at the same address as on testnet. The one exception
+// is `sentio_token`, which here is the WETH9 predeploy; it resolves through the
+// AddressBook like everything else, so nothing in this file needs to know.
 const DEVNET2_CONFIG: SentioNetworkConfig = {
   chainId: 7892301,
-  rpcUrl: 'https://sentio-devnet2.test-rpc.sentio.xyz',
-  explorerUrl: 'https://devnet2-explorer.sentio.xyz',
+  rpcUrl: 'https://sentio-devnet.test-rpc.sentio.xyz',
+  explorerUrl: 'https://devnet-explorer.sentio.xyz',
   addressBookAddress: '0xb7e9E56DFC27bcfA63698F2F5890e186426A0123'
 }
 
@@ -42,7 +47,7 @@ export function getSentioNetworkConfig(network: string, addressBookOverride?: st
   let config: SentioNetworkConfig
   if (network === 'testnet' || network === 'testnet-v2' || network === '7892102') {
     config = TESTNET_CONFIG
-  } else if (network === 'devnet2' || network === 'devnet-v2' || network === '7892301') {
+  } else if (network === 'devnet' || network === 'devnet2' || network === 'devnet-v2' || network === '7892301') {
     config = DEVNET2_CONFIG
   } else if (network === 'mainnet' || network === '789210') {
     console.error(chalk.red('Sentio Network mainnet is not yet supported. Only testnet and devnet2 are available.'))


### PR DESCRIPTION
## What

`--sentio-network` only accepted testnet (chain id 7892102), so there was no way to point the CLI at the Sentio devnet (chain id 7892301).

`--address-book` was not a workaround: the contracts are deployed deterministically, so devnet's AddressBook sits at the **same address** as testnet's. What actually differs is the chain id and the RPC URL, and neither was overridable.

## Changes

- `network.ts` — add `DEVNET_CONFIG` (chain id 7892301, its own RPC + explorer, same AddressBook address) and accept `devnet` / `7892301`.
- `config.ts` — normalize `devnet` to `7892301` in `overrideConfigWithOptions`.
- `upload.ts`, `stop-processor.ts` — update `--sentio-network` / `--no-platform` help text, which claimed testnet was the only option.

No behavior change for existing testnet or mainnet callers.

## On the hostnames

The RPC host is **`sentio-devnet`**. 7892301 replaced the original devnet (7892201), which has been decommissioned, and inherited its hosts — `sentio-devnet.test-rpc.sentio.xyz` and `devnet-explorer.sentio.xyz`. There is no `sentio-devnet2`: that hostname is unrouted and answers `unknown network slug`. Same shape as testnet-v2 taking over the plain testnet hosts.

The user-facing name is just `devnet` — no `devnet2` / `devnet-v2` aliases. `sentio-devnet2` survives only in a code comment, so nobody reaches for it again.

## Verification

- `tsc --noEmit` on `packages/cli` — no new errors (the one pre-existing error, an unbuilt `protos/dist` import, is present on `main` too).
- `devnet` and `7892301` both resolve to chain id 7892301 with the right RPC; `testnet` unchanged.
- `resolveNetworkAddresses()` run **over the public RPC** resolves all six contracts through the AddressBook — `processor_registry`, `controller`, `sentio_token`, `billing`, `databases`, `permissions`.

One thing worth knowing: on this chain `sentio_token` resolves to the WETH9 predeploy (`0x4200…0006`) rather than a standalone ERC20 as on testnet. Because every address goes through the AddressBook, nothing in the CLI needs to special-case it — noted in a comment so it isn't mistaken for a misconfiguration later.

*(History: the first revision pointed at `sentio-devnet2.test-rpc.sentio.xyz` and carried a caveat that the endpoint was not routed. That was the wrong hostname rather than a missing route — fixed in the second commit, and the third drops the devnet2/devnet-v2 naming entirely. Rebased onto current main, which picked up the related @sentio/chain bumps in #108/#109.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAQaaE2TmyQzRSK6yc18dA