### PR TITLE
chore(deps): bump @sentio/chain to 3.4.35 for the Sentio devnet reset

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "@iota/iota-sdk": "~1.14.0",
     "@mysten/sui": "~2.20.0",
     "@sentio/api": "~2.0.4",
-    "@sentio/chain": "~3.4.34",
+    "@sentio/chain": "~3.4.35",
     "@sentio/graph-cli": "^0.97.0",
     "@types/node": "^24.0.0",
     "chalk": "^5.3.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -97,7 +97,7 @@
     "@protobuf-ts/grpcweb-transport": "^2.11.1",
     "@sentio/api": "~2.0.4",
     "@sentio/bigdecimal": "9.1.1-patch.3",
-    "@sentio/chain": "~3.4.34",
+    "@sentio/chain": "~3.4.35",
     "@sentio/ethers-v6": "^1.0.29",
     "@sentio/protos": "workspace:*",
     "@sentio/runtime": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ~2.0.4
         version: 2.0.4
       '@sentio/chain':
-        specifier: ~3.4.34
-        version: 3.4.34
+        specifier: ~3.4.35
+        version: 3.4.35
       '@sentio/graph-cli':
         specifier: ^0.97.0
         version: 0.97.0(@types/node@24.10.13)(bufferutil@4.0.8)(typescript@6.0.3)(utf-8-validate@5.0.10)(zod@3.24.2)
@@ -479,8 +479,8 @@ importers:
         specifier: 9.1.1-patch.3
         version: 9.1.1-patch.3
       '@sentio/chain':
-        specifier: ~3.4.34
-        version: 3.4.34
+        specifier: ~3.4.35
+        version: 3.4.35
       '@sentio/ethers-v6':
         specifier: ^1.0.29
         version: 1.0.29(ethers@6.17.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@6.0.3)
@@ -2541,8 +2541,8 @@ packages:
   '@sentio/bigdecimal@9.1.1-patch.3':
     resolution: {integrity: sha512-O5w8XdyeatUcwI+ZbpSw60/cXFPJk3NbpIupwMHfYmW8fpxpXyRbyGESNJNufWWrB6CadsWGh1R3rd7owvrmlw==}
 
-  '@sentio/chain@3.4.34':
-    resolution: {integrity: sha512-RdD+dYwWHxDU2WUnvEwD6IjmZaQbGwfTPaxiyJTtXA7DPau3LmiDeEEqsvgouKeBdEWsaHUpcyoyLkY6fRbtfg==}
+  '@sentio/chain@3.4.35':
+    resolution: {integrity: sha512-3sAlr9nsN7QYNKwrQUpNddPLB7H0HHPSI7+KlJW7GK3/OSkwQSfGeyaSKUqjRDahMHhcp3Vou6d+6Dt33hn0YA==}
 
   '@sentio/connect-gateway-es@1.0.0':
     resolution: {integrity: sha512-232yOipLgnGVgfvEGJrNOetkgoDlPvEXMAWCae305+E9YYnQBb7+OCLCnkHJjICFgf49obnoQWgt3uNjP9C7JA==}
@@ -9484,7 +9484,7 @@ snapshots:
 
   '@sentio/bigdecimal@9.1.1-patch.3': {}
 
-  '@sentio/chain@3.4.34': {}
+  '@sentio/chain@3.4.35': {}
 
   '@sentio/connect-gateway-es@1.0.0(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))':
     dependencies:


### PR DESCRIPTION
## Summary

The Sentio devnet was reset onto a new network: the L2 chain ID moved from `7892201` to `7892301` and the explorer to https://devnet2-explorer.sentio.xyz. `@sentio/chain` **3.4.35** carries the updated registry (https://github.com/sentioxyz/sentio-core/pull/417).

Bump the dependency range in `@sentio/cli` and `@sentio/sdk` from `~3.4.34` to `~3.4.35` (and refresh the lockfile) so processors built for `sentio-devnet` target the new chain instead of the retired one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)