### PR TITLE
fix(eth): give ethers its own keep-alive agent so connects are not cut at Node's 5s default

### DIFF
--- a/packages/sdk/src/eth/provider.ts
+++ b/packages/sdk/src/eth/provider.ts
@@ -1,10 +1,11 @@
 import { JsonRpcProvider, Network, hexlify } from 'ethers'
-import type { JsonRpcError, JsonRpcPayload, JsonRpcResult } from 'ethers'
+import type { FetchRequest, JsonRpcError, JsonRpcPayload, JsonRpcResult } from 'ethers'
 
 import PQueue from 'p-queue'
 import { EthChainId } from '@sentio/chain'
 import { LRUCache } from 'lru-cache'
 import { Endpoints, providerMetrics, processMetrics, metricsStorage, GLOBAL_CONFIG } from '@sentio/runtime'
+import { rpcCallTimeoutMs, rpcFetchRequest } from './rpc-agent.js'
 const { miss_count, hit_count, queue_size } = providerMetrics
 
 export const DummyProvider = new JsonRpcProvider('', Network.from(1))
@@ -50,24 +51,15 @@ export function getProvider(chainId?: EthChainId): JsonRpcProvider {
   // console.log(
   //   `init provider for chain ${network.chainId}, concurrency: ${Endpoints.INSTANCE.concurrency}, batchCount: ${Endpoints.INSTANCE.batchCount}`
   // )
+  // Our own transport agents: see rpc-agent.ts for why the default agent is not usable here.
   provider = new QueuedStaticJsonRpcProvider(
-    address,
+    rpcFetchRequest(address),
     network,
     Endpoints.INSTANCE.concurrency,
     Endpoints.INSTANCE.batchCount
   )
   providers.set(key, provider)
   return provider
-}
-
-// Default upper bound for a single RPC promise to settle, queue wait included.
-// Deliberately above any sane queue+request latency and far below "stuck forever".
-const DEFAULT_RPC_CALL_TIMEOUT_MS = 120_000
-
-// Read per call so tests (and operators) can adjust without a module reload.
-function rpcCallTimeoutMs(): number {
-  const n = Number(process.env['RPC_CALL_TIMEOUT_MS'])
-  return Number.isFinite(n) && n > 0 ? n : DEFAULT_RPC_CALL_TIMEOUT_MS
 }
 
 // Keep the diagnostic bounded: `what` may describe params with large calldata.
@@ -181,7 +173,7 @@ export class QueuedStaticJsonRpcProvider extends JsonRpcProvider {
     max: 300000 // 300k items
   })
 
-  constructor(url: string, network: Network, concurrency: number, batchCount = 1) {
+  constructor(url: string | FetchRequest, network: Network, concurrency: number, batchCount = 1) {
     // TODO re-enable match when possible
     super(url, network, { staticNetwork: network, batchMaxCount: batchCount })
     this.executor = new PQueue({ concurrency: concurrency })

--- a/packages/sdk/src/eth/rpc-agent.test.ts
+++ b/packages/sdk/src/eth/rpc-agent.test.ts
@@ -1,0 +1,109 @@
+import { after, before, describe, test } from 'node:test'
+import { expect } from 'chai'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { Network } from 'ethers'
+import { FREE_SOCKET_IDLE_MS, createRpcHttpAgent, rpcAgents, rpcCallTimeoutMs, rpcFetchRequest } from './rpc-agent.js'
+import { QueuedStaticJsonRpcProvider } from './provider.js'
+
+// A tiny JSON-RPC endpoint: answers every request with result "0x1".
+function startRpcServer(): Promise<http.Server> {
+  const server = http.createServer((req, res) => {
+    let body = ''
+    req.on('data', (c) => (body += c))
+    req.on('end', () => {
+      const payload = JSON.parse(body || '{}')
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: payload.id ?? 1, result: '0x1' }))
+    })
+  })
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server)))
+}
+
+function urlOf(server: http.Server): string {
+  const { port } = server.address() as AddressInfo
+  return `http://127.0.0.1:${port}`
+}
+
+function freeSocketsOf(agent: http.Agent) {
+  return Object.values(agent.freeSockets).flatMap((sockets) => sockets ?? [])
+}
+
+const nextTurn = () => new Promise((resolve) => setImmediate(resolve))
+
+describe('rpc agent', () => {
+  let server: http.Server
+  const agents: http.Agent[] = []
+
+  before(async () => {
+    server = await startRpcServer()
+  })
+
+  after(() => {
+    delete process.env['RPC_CALL_TIMEOUT_MS']
+    for (const a of agents) a.destroy()
+    rpcAgents().http.destroy()
+    server.close()
+  })
+
+  test('a new socket carries the RPC deadline as its timeout while it is still connecting', async () => {
+    process.env['RPC_CALL_TIMEOUT_MS'] = '7000'
+    const agent = createRpcHttpAgent()
+    agents.push(agent)
+    const seen = await new Promise<{ connecting: boolean; timeout: number }>((resolve, reject) => {
+      const req = http.request(urlOf(server), { method: 'POST', agent })
+      req.on('socket', (socket) => resolve({ connecting: socket.connecting, timeout: socket.timeout ?? -1 }))
+      req.on('error', reject)
+      req.end('{}')
+    })
+    // The timeout that applies during DNS + TCP connect is the agent's, not the one the
+    // request sets later; it must be our deadline, not Node's 5s global-agent default.
+    expect(seen.connecting).eq(true)
+    expect(seen.timeout).eq(7000)
+    expect(rpcCallTimeoutMs()).eq(7000)
+  })
+
+  test('an idle keep-alive socket is kept, with the short idle retention', async () => {
+    const agent = createRpcHttpAgent()
+    agents.push(agent)
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(urlOf(server), { method: 'POST', agent }, (res) => {
+        res.resume()
+        res.on('end', resolve)
+      })
+      req.on('error', reject)
+      req.end('{}')
+    })
+    await nextTurn()
+    const free = freeSocketsOf(agent)
+    expect(free.length).eq(1)
+    expect(free[0].timeout).eq(FREE_SOCKET_IDLE_MS)
+  })
+
+  test('the default global agent is why this exists: 5s during connect on Node >= 19', () => {
+    // Documents the behaviour we are working around; if Node ever changes it this test says so.
+    const globalAgent = http.globalAgent as unknown as { options: http.AgentOptions }
+    expect(globalAgent.options.timeout).eq(5000)
+  })
+
+  test('a FetchRequest from rpcFetchRequest goes through the SDK agent, clones included', async () => {
+    const before = freeSocketsOf(rpcAgents().http).length
+    const req = rpcFetchRequest(urlOf(server)).clone()
+    expect(req.getUrlFunc).eq(rpcAgents().getUrlFunc)
+    req.body = { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }
+    const resp = await req.send()
+    expect(resp.bodyJson.result).eq('0x1')
+    await nextTurn()
+    expect(freeSocketsOf(rpcAgents().http).length).gt(before)
+  })
+
+  test('QueuedStaticJsonRpcProvider accepts the FetchRequest and answers over it', async () => {
+    const provider = new QueuedStaticJsonRpcProvider(rpcFetchRequest(urlOf(server)), Network.from(1), 4, 1)
+    try {
+      const result = await provider.send('eth_blockNumber', [])
+      expect(result).eq('0x1')
+    } finally {
+      provider.destroy()
+    }
+  })
+})

--- a/packages/sdk/src/eth/rpc-agent.test.ts
+++ b/packages/sdk/src/eth/rpc-agent.test.ts
@@ -3,21 +3,47 @@ import { expect } from 'chai'
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { Network } from 'ethers'
-import { FREE_SOCKET_IDLE_MS, createRpcHttpAgent, rpcAgents, rpcCallTimeoutMs, rpcFetchRequest } from './rpc-agent.js'
+import {
+  FREE_SOCKET_IDLE_MS,
+  createRpcHttpAgent,
+  freeSocketIdleMs,
+  isHttpsUrl,
+  rpcAgents,
+  rpcCallTimeoutMs,
+  rpcFetchRequest
+} from './rpc-agent.js'
 import { QueuedStaticJsonRpcProvider } from './provider.js'
 
-// A tiny JSON-RPC endpoint: answers every request with result "0x1".
-function startRpcServer(): Promise<http.Server> {
+// A tiny JSON-RPC endpoint: answers every request with result "0x1". With `keepAliveSecs` it
+// also advertises `Keep-Alive: timeout=<secs>`, the way a real server announces its idle limit.
+function startRpcServer(keepAliveSecs?: number): Promise<http.Server> {
   const server = http.createServer((req, res) => {
     let body = ''
     req.on('data', (c) => (body += c))
     req.on('end', () => {
       const payload = JSON.parse(body || '{}')
       res.setHeader('content-type', 'application/json')
+      if (keepAliveSecs !== undefined) {
+        res.setHeader('keep-alive', `timeout=${keepAliveSecs}`)
+      }
       res.end(JSON.stringify({ jsonrpc: '2.0', id: payload.id ?? 1, result: '0x1' }))
     })
   })
+  // 0 also stops Node's default `Keep-Alive: timeout=5` header, so the plain server hints nothing.
+  server.keepAliveTimeout = keepAliveSecs === undefined ? 0 : keepAliveSecs * 1000
   return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server)))
+}
+
+// One request over `agent`, fully consumed, so the socket goes back to the free pool.
+function requestOnce(url: string, agent: http.Agent): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const req = http.request(url, { method: 'POST', agent }, (res) => {
+      res.resume()
+      res.on('end', resolve)
+    })
+    req.on('error', reject)
+    req.end('{}')
+  })
 }
 
 function urlOf(server: http.Server): string {
@@ -66,18 +92,49 @@ describe('rpc agent', () => {
   test('an idle keep-alive socket is kept, with the short idle retention', async () => {
     const agent = createRpcHttpAgent()
     agents.push(agent)
-    await new Promise<void>((resolve, reject) => {
-      const req = http.request(urlOf(server), { method: 'POST', agent }, (res) => {
-        res.resume()
-        res.on('end', resolve)
-      })
-      req.on('error', reject)
-      req.end('{}')
-    })
+    await requestOnce(urlOf(server), agent)
     await nextTurn()
     const free = freeSocketsOf(agent)
     expect(free.length).eq(1)
     expect(free[0].timeout).eq(FREE_SOCKET_IDLE_MS)
+  })
+
+  test('a shorter server Keep-Alive hint wins over the idle retention', async () => {
+    // Node keeps the socket for the advertised 2s minus its 1s safety buffer; we must not
+    // stretch that back to 5s, or the next reuse races the server closing the idle socket.
+    const hinting = await startRpcServer(2)
+    const agent = createRpcHttpAgent()
+    agents.push(agent)
+    try {
+      await requestOnce(urlOf(hinting), agent)
+      await nextTurn()
+      const free = freeSocketsOf(agent)
+      expect(free.length).eq(1)
+      expect(free[0].timeout).eq(1000)
+    } finally {
+      hinting.close()
+    }
+  })
+
+  test('freeSocketIdleMs never lengthens what Node selected', () => {
+    expect(freeSocketIdleMs(1000)).eq(1000)
+    expect(freeSocketIdleMs(FREE_SOCKET_IDLE_MS)).eq(FREE_SOCKET_IDLE_MS)
+    expect(freeSocketIdleMs(120_000)).eq(FREE_SOCKET_IDLE_MS)
+    expect(freeSocketIdleMs(0)).eq(FREE_SOCKET_IDLE_MS)
+    expect(freeSocketIdleMs(undefined)).eq(FREE_SOCKET_IDLE_MS)
+  })
+
+  test('the agent is picked by scheme, case-insensitively, like ethers picks the transport', async () => {
+    expect(isHttpsUrl('https://rpc.example')).eq(true)
+    expect(isHttpsUrl('HTTPS://rpc.example')).eq(true)
+    expect(isHttpsUrl('Https://rpc.example')).eq(true)
+    expect(isHttpsUrl('http://rpc.example')).eq(false)
+    expect(isHttpsUrl('HTTP://rpc.example')).eq(false)
+    // A mixed-case http URL must still go out over the http agent and get answered.
+    const req = rpcFetchRequest(urlOf(server).replace('http://', 'HTTP://'))
+    req.body = { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }
+    const resp = await req.send()
+    expect(resp.bodyJson.result).eq('0x1')
   })
 
   test('the default global agent is why this exists: 5s during connect on Node >= 19', () => {
@@ -87,14 +144,15 @@ describe('rpc agent', () => {
   })
 
   test('a FetchRequest from rpcFetchRequest goes through the SDK agent, clones included', async () => {
-    const before = freeSocketsOf(rpcAgents().http).length
     const req = rpcFetchRequest(urlOf(server)).clone()
     expect(req.getUrlFunc).eq(rpcAgents().getUrlFunc)
     req.body = { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] }
     const resp = await req.send()
     expect(resp.bodyJson.result).eq('0x1')
     await nextTurn()
-    expect(freeSocketsOf(rpcAgents().http).length).gt(before)
+    // The only way a socket to this server ends up in the SDK agent's pool is through it.
+    const { port } = server.address() as AddressInfo
+    expect(freeSocketsOf(rpcAgents().http).some((s) => s.remotePort === port)).eq(true)
   })
 
   test('QueuedStaticJsonRpcProvider accepts the FetchRequest and answers over it', async () => {

--- a/packages/sdk/src/eth/rpc-agent.ts
+++ b/packages/sdk/src/eth/rpc-agent.ts
@@ -34,8 +34,11 @@ export function rpcCallTimeoutMs(): number {
 }
 
 // `timeout` on an Agent doubles as the idle timeout of its free sockets; we want a long connect
-// timeout but a short idle retention, so shorten the timer again when a socket goes back to
-// the free pool. (`keepSocketAlive` is the documented hook Node calls exactly at that point.)
+// timeout but a short idle retention, so cap the timer again when a socket goes back to the
+// free pool. (`keepSocketAlive` is the documented hook Node calls exactly at that point.) The
+// base hook already honours a server `Keep-Alive: timeout=N` hint, minus Node's safety buffer,
+// whenever that is shorter than the agent timeout — keep whichever is shorter, never lengthen
+// it: an idle socket that outlives the server's idle timeout is a reset waiting to happen.
 // (@types/node does not declare the hook, hence the structural cast.)
 interface KeepSocketAlive {
   keepSocketAlive(socket: Socket): boolean
@@ -47,11 +50,22 @@ function keepAliveWithShortIdle<T extends http.Agent | https.Agent>(agent: T): T
   hooks.keepSocketAlive = (socket: Socket): boolean => {
     const keep = base(socket)
     if (keep) {
-      socket.setTimeout(FREE_SOCKET_IDLE_MS)
+      socket.setTimeout(freeSocketIdleMs(socket.timeout))
     }
     return keep
   }
   return agent
+}
+
+// The idle timeout to leave on a freed socket, given the one Node's hook selected for it.
+export function freeSocketIdleMs(selected: number | undefined): number {
+  return selected && selected > 0 ? Math.min(selected, FREE_SOCKET_IDLE_MS) : FREE_SOCKET_IDLE_MS
+}
+
+// Same scheme test ethers' node transport applies (case-insensitive), so a request never lands
+// on an agent for the other protocol.
+export function isHttpsUrl(url: string): boolean {
+  return url.split(':')[0].toLowerCase() === 'https'
 }
 
 export function rpcAgentOptions(extra?: http.AgentOptions): http.AgentOptions {
@@ -86,7 +100,7 @@ export function rpcAgents(): RpcAgents {
     agents = {
       http: viaHttp,
       https: viaHttps,
-      getUrlFunc: (req, signal) => (req.url.startsWith('https:') ? overHttps : overHttp)(req, signal)
+      getUrlFunc: (req, signal) => (isHttpsUrl(req.url) ? overHttps : overHttp)(req, signal)
     }
   }
   return agents

--- a/packages/sdk/src/eth/rpc-agent.ts
+++ b/packages/sdk/src/eth/rpc-agent.ts
@@ -1,0 +1,101 @@
+import http from 'node:http'
+import https from 'node:https'
+import type { Socket } from 'node:net'
+import { FetchRequest } from 'ethers'
+import type { FetchGetUrlFunc } from 'ethers'
+
+// Node >= 19 ships `http.globalAgent` as `{ keepAlive: true, timeout: 5000 }`. That agent
+// timeout is installed on every NEW socket at creation and stays in force for the whole
+// DNS + TCP connect phase: ethers' own `request.setTimeout(300s)` only replaces it once the
+// socket has connected (Node defers it with `socket.once('connect', ...)` while connecting).
+// So a connect that takes more than 5s — a slow resolver, or the worker's event loop being
+// busy when the connect completes — surfaces as an ethers `request timeout`, even though the
+// request then goes out anyway and is answered in milliseconds. Idle keep-alive sockets are
+// also dropped after those same 5s, so a briefly idle worker reconnects (and re-resolves) for
+// almost every call, which is what keeps putting requests into that window.
+//
+// Use our own agents instead: the connect-phase socket timeout is the RPC deadline, so the
+// deadline in boundedTask is the only clock a call can run out on; idle keep-alive sockets
+// keep Node's short retention so a server-side idle close never races a reuse.
+
+// How long an idle keep-alive socket is kept before we drop it ourselves. Same value Node's
+// global agent uses; well below the idle timeout of any RPC endpoint or proxy in front of one.
+export const FREE_SOCKET_IDLE_MS = 5_000
+
+// Default upper bound for a single RPC promise to settle, queue wait included.
+// Deliberately above any sane queue+request latency and far below "stuck forever".
+// Also the socket timeout for the connect phase of a new connection.
+const DEFAULT_RPC_CALL_TIMEOUT_MS = 120_000
+
+// Read per call so tests (and operators) can adjust without a module reload.
+export function rpcCallTimeoutMs(): number {
+  const n = Number(process.env['RPC_CALL_TIMEOUT_MS'])
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_RPC_CALL_TIMEOUT_MS
+}
+
+// `timeout` on an Agent doubles as the idle timeout of its free sockets; we want a long connect
+// timeout but a short idle retention, so shorten the timer again when a socket goes back to
+// the free pool. (`keepSocketAlive` is the documented hook Node calls exactly at that point.)
+// (@types/node does not declare the hook, hence the structural cast.)
+interface KeepSocketAlive {
+  keepSocketAlive(socket: Socket): boolean
+}
+
+function keepAliveWithShortIdle<T extends http.Agent | https.Agent>(agent: T): T {
+  const hooks = agent as unknown as KeepSocketAlive
+  const base = hooks.keepSocketAlive.bind(agent)
+  hooks.keepSocketAlive = (socket: Socket): boolean => {
+    const keep = base(socket)
+    if (keep) {
+      socket.setTimeout(FREE_SOCKET_IDLE_MS)
+    }
+    return keep
+  }
+  return agent
+}
+
+export function rpcAgentOptions(extra?: http.AgentOptions): http.AgentOptions {
+  return { keepAlive: true, scheduling: 'lifo', timeout: rpcCallTimeoutMs(), ...extra }
+}
+
+export function createRpcHttpAgent(extra?: http.AgentOptions): http.Agent {
+  return keepAliveWithShortIdle(new http.Agent(rpcAgentOptions(extra)))
+}
+
+export function createRpcHttpsAgent(extra?: https.AgentOptions): https.Agent {
+  return keepAliveWithShortIdle(new https.Agent(rpcAgentOptions(extra)))
+}
+
+export interface RpcAgents {
+  readonly http: http.Agent
+  readonly https: https.Agent
+  readonly getUrlFunc: FetchGetUrlFunc
+}
+
+let agents: RpcAgents | undefined
+
+// The process-wide agents every FetchRequest the SDK hands to ethers goes through, plus the
+// `getUrlFunc` that routes a request to the one matching its scheme. Built lazily so the
+// agents pick up RPC_CALL_TIMEOUT_MS from the environment the processor actually runs in.
+export function rpcAgents(): RpcAgents {
+  if (!agents) {
+    const viaHttp = createRpcHttpAgent()
+    const viaHttps = createRpcHttpsAgent()
+    const overHttp = FetchRequest.createGetUrlFunc({ agent: viaHttp })
+    const overHttps = FetchRequest.createGetUrlFunc({ agent: viaHttps })
+    agents = {
+      http: viaHttp,
+      https: viaHttps,
+      getUrlFunc: (req, signal) => (req.url.startsWith('https:') ? overHttps : overHttp)(req, signal)
+    }
+  }
+  return agents
+}
+
+// A FetchRequest for `url` whose transport uses the SDK agents. Clones keep the getUrlFunc, so
+// this is safe to hand to a JsonRpcProvider, which clones it once per request.
+export function rpcFetchRequest(url: string): FetchRequest {
+  const req = new FetchRequest(url)
+  req.getUrlFunc = rpcAgents().getUrlFunc
+  return req
+}


### PR DESCRIPTION
## Problem

Processors on Node >= 19 occasionally fail an `eth_call` with an ethers `request timeout (code=TIMEOUT)` while the RPC endpoint answers the very same request in milliseconds. Each such error ends the handler and stops the processor.

Traced on a production processor (SDK 4.3.4, Node 24.13): the "timed-out" request reached the RPC proxy at the exact millisecond the error was raised, got a 200 in 5 ms, and every occurrence sat a few seconds after the driver restarted the run to bind new templates.

## Root cause

`http.globalAgent` on Node >= 19 is `{ keepAlive: true, timeout: 5000 }`. That agent timeout is installed on every **new** socket at creation and stays in force for the whole DNS + TCP connect phase: ethers' own `request.setTimeout(300s)` is deferred by Node with `socket.once('connect', ...)` while the socket is connecting, so it only takes over after the connect. Any connect that takes more than 5 s (a slow resolver, or the worker's event loop being busy, e.g. re-binding tens of thousands of templates, when the connect completes) therefore fires the 5 s socket timeout: ethers rejects with `TIMEOUT`, the request still goes out and is answered, and nobody is listening.

The same 5 s also drops idle keep-alive sockets, so a briefly idle worker reconnects for almost every call, which is what keeps putting `eth_call`s into that window. The 120 s deadline from #110 does not help: the 5 s timer fires first.

Reproduced inside a processor container with `http.request()` to a blackhole IP plus `request.setTimeout(300000)`: the `timeout` event fires after 5005 ms.

## Fix

Every `FetchRequest` the SDK hands to ethers now goes through SDK-owned `http`/`https` agents (`packages/sdk/src/eth/rpc-agent.ts`):

- keep-alive stays on;
- the agent `timeout`, i.e. the socket timeout during the connect phase, is the RPC deadline (`RPC_CALL_TIMEOUT_MS`, default 120 s), so the bounded deadline is the only clock a call can run out on;
- idle sockets in the free pool are still dropped after 5 s (via the documented `keepSocketAlive` hook), so a server-side idle close never races a reuse.

`QueuedStaticJsonRpcProvider` now accepts `string | FetchRequest`; `getProvider` passes a `FetchRequest` built by `rpcFetchRequest`, whose `getUrlFunc` survives ethers' per-request `clone()`. The `rpcCallTimeoutMs` helper moved to `rpc-agent.ts` so both the deadline and the agents read the same value.

## Tests

`rpc-agent.test.ts` checks, against a local HTTP server: a connecting socket carries the deadline as its timeout (not 5000), a freed socket carries the 5 s idle retention, the global agent still has the 5 s default this works around, a cloned `FetchRequest` from `rpcFetchRequest` really goes through the SDK agent, and `QueuedStaticJsonRpcProvider` answers over it. Existing `provider.test.ts` deadline tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
